### PR TITLE
Corrected transaction details page to use correct property for querystring

### DIFF
--- a/app/views/transactionDetails.html
+++ b/app/views/transactionDetails.html
@@ -38,7 +38,7 @@
             </div>
             <div class="data-group left-indent">
                 <label>Request Parameters: </label>
-                <div class="data-value">{{transactionDetails.request.requestParams}}</div>
+                <div class="data-value">{{transactionDetails.request.querystring}}</div>
             </div>
             <div class="data-group left-indent">
                 <label>HTTP Method: </label>


### PR DESCRIPTION
Part of the fix for https://github.com/jembi/openhim-core-js/issues/68
