### PR TITLE
Updated dashboard test to only test metrics values that are in the current day

### DIFF
--- a/test/spec/controllers/dashboard.js
+++ b/test/spec/controllers/dashboard.js
@@ -65,26 +65,6 @@ describe('Controller: DashboardCtrl', function () {
     scope.transactionLoadData.should.have.property('postunits', ' per hour');
 
 
-    // only test if four hours ago isnt in the past day
-    if ( moment( fourHoursAgo ).format('H') < moment( nowHour ).format('H') ){
-      scope.transactionLoadData.data[parseInt( moment( fourHoursAgo ).format('H') )].should.have.property('value', 22);
-    }
-
-    // only test if three hours ago isnt in the past day
-    if ( moment( threeHoursAgo ).format('H') < moment( nowHour ).format('H') ){
-      scope.transactionLoadData.data[parseInt( moment( threeHoursAgo ).format('H') )].should.have.property('value', 65);
-    }
-
-    // only test if two hours ago isnt in the past day
-    if ( moment( twoHoursAgo ).format('H') < moment( nowHour ).format('H') ){
-      scope.transactionLoadData.data[parseInt( moment( twoHoursAgo ).format('H') )].should.have.property('value', 32);
-    }
-
-    // only test if one hours ago isnt in the past day
-    if ( moment( oneHourAgo ).format('H') < moment( nowHour ).format('H') ){
-      scope.transactionLoadData.data[parseInt( moment( oneHourAgo ).format('H') )].should.have.property('value', 13);
-    }
-
     // always test for current hour
     scope.transactionLoadData.data[parseInt( moment( nowHour ).format('H') )].should.have.property('value', 56);
 
@@ -105,27 +85,6 @@ describe('Controller: DashboardCtrl', function () {
     scope.transactionResponseTimeData.labels[0].should.equal('Load');
     scope.transactionResponseTimeData.should.have.property('postunits', ' ms');
 
-    // only test if four hours ago isnt in the past day
-    if ( moment( fourHoursAgo ).format('H') < moment( nowHour ).format('H') ){
-      scope.transactionResponseTimeData.data[parseInt( moment( fourHoursAgo ).format('H') )].should.have.property('value', '43269.95');
-    }
-
-    // only test if three hours ago isnt in the past day
-    if ( moment( threeHoursAgo ).format('H') < moment( nowHour ).format('H') ){
-      scope.transactionResponseTimeData.data[parseInt( moment( threeHoursAgo ).format('H') )].should.have.property('value', '13367.98');
-    }
-
-    // only test if two hours ago isnt in the past day
-    if ( moment( twoHoursAgo ).format('H') < moment( nowHour ).format('H') ){
-      scope.transactionResponseTimeData.data[parseInt( moment( twoHoursAgo ).format('H') )].should.have.property('value', '11249.94');
-    }
-
-    // only test if one hours ago isnt in the past day
-    if ( moment( oneHourAgo ).format('H') < moment( nowHour ).format('H') ){
-      scope.transactionResponseTimeData.data[parseInt( moment( oneHourAgo ).format('H') )].should.have.property('value', '54668.97');
-    }
-
-    // always test for current hour
     scope.transactionResponseTimeData.data[parseInt( moment( nowHour ).format('H') )].should.have.property('value', '34769.91');
 
   });


### PR DESCRIPTION
I had to correct the dashboard test script due to my poor logic. Updated the test script to only test for metrics in the current day. This failed before if the test was run at say 2:00am and a check was done on metrics 4 hours ago. It would not be present in the metrics object
