### PR TITLE
Fixed ngInclude reference for the user settings options

### DIFF
--- a/app/views/profile.html
+++ b/app/views/profile.html
@@ -94,7 +94,7 @@
 
               
               <!-- include for user settings tabs -->
-              <div ng-include="'views/user-settings-tabs.html'" style="margin-bottom: 20px;"></div>
+              <div ng-include="'views/partials/user-settings-tabs.html'" style="margin-bottom: 20px;"></div>
 
 
             </fieldset>


### PR DESCRIPTION
Found an issue with the Profile page user settings. I moved the user-settings include script into the partials folder but didnt update the link for the profile page. 