### PR TITLE
Removed seconds tooltip from mediator uptime field

### DIFF
--- a/app/scripts/services/mediatorDisplay.js
+++ b/app/scripts/services/mediatorDisplay.js
@@ -28,6 +28,7 @@ angular.module('openhimConsoleApp')
       if (mediator._uptime) {
         //generate human-friendly display string, e.g. 4 days
         mediator.uptimeDisplay = moment().subtract(mediator._uptime, 'seconds').fromNow(true);
+        mediator.uptimeSince = moment(mediator._lastHeartbeat).subtract(mediator._uptime, 'seconds').toDate();
       }
     };
 

--- a/app/views/mediatorDetails.html
+++ b/app/views/mediatorDetails.html
@@ -45,7 +45,7 @@
             </tr>
             <tr>
               <td><strong>Uptime at last heartbeat: </strong></td>
-              <td><span ng-if="mediatorDetails._uptime">{{mediatorDetails.uptimeDisplay}}</span></td>
+              <td><span ng-if="mediatorDetails._uptime" tooltip-html-unsafe="Startup time<br>{{mediatorDetails.uptimeSince | date:'yyyy-MM-dd HH:mm:ss'}}">{{mediatorDetails.uptimeDisplay}}</span></td>
             </tr>
             <tr>
               <td><strong>Endpoints: </strong></td>

--- a/app/views/mediatorDetails.html
+++ b/app/views/mediatorDetails.html
@@ -45,7 +45,7 @@
             </tr>
             <tr>
               <td><strong>Uptime at last heartbeat: </strong></td>
-              <td><span ng-if="mediatorDetails._uptime" tooltip="{{mediatorDetails._uptime}} s">{{mediatorDetails.uptimeDisplay}}</td>
+              <td><span ng-if="mediatorDetails._uptime">{{mediatorDetails.uptimeDisplay}}</span></td>
             </tr>
             <tr>
               <td><strong>Endpoints: </strong></td>

--- a/app/views/mediators.html
+++ b/app/views/mediators.html
@@ -48,7 +48,7 @@
                     <div>
                     </div>
                   </td>
-                  <td data-title="Uptime">{{ mediator.uptimeDisplay }}</td>
+                  <td data-title="Uptime"><span ng-if="mediator._uptime" tooltip-html-unsafe="Startup time<br>{{mediator.uptimeSince | date:'yyyy-MM-dd HH:mm:ss'}}">{{ mediator.uptimeDisplay }}</td>
                   <td>
                     <button class="btn btn-info btn-xs" ng-click="editMediatorConfig(mediator)" tooltip="configure mediator"><i class="glyphicon glyphicon-cog"></i></button>
                     <button class="btn btn-danger btn-xs" ng-click="confirmDelete(mediator)"><i class="glyphicon glyphicon-remove"></i></button>

--- a/app/views/mediators.html
+++ b/app/views/mediators.html
@@ -48,7 +48,7 @@
                     <div>
                     </div>
                   </td>
-                  <td data-title="Uptime"><span tooltip="{{mediator._uptime}} s">{{ mediator.uptimeDisplay }}</span></td>
+                  <td data-title="Uptime">{{ mediator.uptimeDisplay }}</td>
                   <td>
                     <button class="btn btn-info btn-xs" ng-click="editMediatorConfig(mediator)" tooltip="configure mediator"><i class="glyphicon glyphicon-cog"></i></button>
                     <button class="btn btn-danger btn-xs" ng-click="confirmDelete(mediator)"><i class="glyphicon glyphicon-remove"></i></button>


### PR DESCRIPTION
@rcrichton just looking at this again, the seconds tooltip on the uptime field is quite ugly. A value in seconds value beyond a couple of minutes really has no meaning to a user. Not sure what i was thinking putting it in :)