### PR TITLE
Transaction details page refactor

### DIFF
--- a/app/scripts/controllers/transactionDetails.js
+++ b/app/scripts/controllers/transactionDetails.js
@@ -13,13 +13,12 @@ angular.module('openhimConsoleApp')
     var querySuccess = function(transactionDetails){
 
       $scope.transactionDetails = transactionDetails;
-      
+
       // transform request body with indentation/formatting
       if( transactionDetails.request && transactionDetails.request.body ){
         if ( transactionDetails.request.headers && returnContentType( transactionDetails.request.headers ) ){
           var requestTransform = beautifyIndent(returnContentType( transactionDetails.request.headers ), transactionDetails.request.body);
           $scope.transactionDetails.request.body = requestTransform.content;
-          $scope.requestTransformLang = requestTransform.lang;
         }
       }
 
@@ -28,7 +27,6 @@ angular.module('openhimConsoleApp')
         if ( transactionDetails.response.headers && returnContentType( transactionDetails.response.headers ) ){
           var responseTransform = beautifyIndent(returnContentType( transactionDetails.response.headers ), transactionDetails.response.body);
           $scope.transactionDetails.response.body = responseTransform.content;
-          $scope.responseTransformLang = responseTransform.lang;
         }
       }
 
@@ -50,7 +48,7 @@ angular.module('openhimConsoleApp')
           }
       }
 
-      
+
       var consoleSession = localStorage.getItem('consoleSession');
       consoleSession = JSON.parse(consoleSession);
       $scope.consoleSession = consoleSession;
@@ -80,7 +78,7 @@ angular.module('openhimConsoleApp')
         // get the client object for the transactions details page
         $scope.client = Api.Clients.get({ clientId: transactionDetails.clientID, property: 'clientName' });
       }
-      
+
 
     };
 
@@ -105,7 +103,7 @@ angular.module('openhimConsoleApp')
     //setup filter options
     $scope.returnFilterObject = function(){
       var filtersObject = {};
-      
+
       filtersObject.filterPage = 0;
       filtersObject.filterLimit = 0;
       filtersObject.filters = {};
@@ -156,7 +154,7 @@ angular.module('openhimConsoleApp')
           rerunTransactionsSelected = 1;
         }
       }
-      
+
       $modal.open({
         templateUrl: 'views/transactionsRerunModal.html',
         controller: 'TransactionsRerunModalCtrl',

--- a/app/scripts/controllers/transactionDetails.js
+++ b/app/scripts/controllers/transactionDetails.js
@@ -85,6 +85,10 @@ angular.module('openhimConsoleApp')
         // get the channels for the transactions filter dropdown
         Api.Channels.get({ channelId: transactionDetails.channelID }, function(channel){
           $scope.channel = channel;
+          $scope.routeDefs = {};
+          channel.routes.forEach(function (route) {
+            $scope.routeDefs[route.name] = route;
+          });
 
           if (typeof channel.status === 'undefined' || channel.status === 'enabled') {
             if ( user.groups.indexOf('admin') >= 0 ){
@@ -206,7 +210,7 @@ angular.module('openhimConsoleApp')
     /**               Transactions View Route Functions                 **/
     /*********************************************************************/
 
-    $scope.viewAddReqResDetails = function(record){
+    $scope.viewAddReqResDetails = function(record, route){
       $modal.open({
         templateUrl: 'views/transactionsAddReqResModal.html',
         controller: 'TransactionsAddReqResModalCtrl',
@@ -214,6 +218,9 @@ angular.module('openhimConsoleApp')
         resolve: {
           record: function () {
             return record;
+          },
+          route: function () {
+            return route;
           }
         }
       });

--- a/app/scripts/controllers/transactionDetails.js
+++ b/app/scripts/controllers/transactionDetails.js
@@ -37,9 +37,6 @@ angular.module('openhimConsoleApp')
       }
     }
 
-    console.log($scope.next);
-    console.log($scope.prev);
-
     var querySuccess = function(transactionDetails){
 
       $scope.transactionDetails = transactionDetails;

--- a/app/scripts/controllers/transactionDetails.js
+++ b/app/scripts/controllers/transactionDetails.js
@@ -10,6 +10,36 @@ angular.module('openhimConsoleApp')
     /**         Initial page load functions           **/
     /***************************************************/
 
+    // get txList for paging
+    var txList = JSON.parse(sessionStorage.getItem('currTxList'));
+
+    $scope.pagingEnabled = true;
+    if (!txList) {
+      $scope.pagingEnabled = false;
+    } else if (txList.indexOf($routeParams.transactionId) === -1) {
+      $scope.pagingEnabled = false;
+    }
+
+    $scope.next = null;
+    $scope.prev = null;
+    if ($scope.pagingEnabled) {
+      var currTxIndex = txList.indexOf($routeParams.transactionId);
+
+      $scope.txNumber = currTxIndex+1;
+      $scope.txTotal = txList.length;
+      $scope.currFilterURL = sessionStorage.getItem('currFilterURL');
+
+      if (currTxIndex !== 0) {
+        $scope.prev = txList[currTxIndex-1];
+      }
+      if (currTxIndex !== txList.length-1) {
+        $scope.next = txList[currTxIndex+1];
+      }
+    }
+
+    console.log($scope.next);
+    console.log($scope.prev);
+
     var querySuccess = function(transactionDetails){
 
       $scope.transactionDetails = transactionDetails;

--- a/app/scripts/controllers/transactions.js
+++ b/app/scripts/controllers/transactions.js
@@ -406,6 +406,12 @@ angular.module('openhimConsoleApp')
       // on success
       $scope.transactions = transactions;
 
+      // save latest returned transaction to session storage for use in transaction
+      // details paging.
+      var idList = transactions.map(function (tx) { return tx._id; });
+      sessionStorage.setItem('currTxList', angular.toJson(idList));
+      sessionStorage.setItem('currFilterURL', $location.url());
+
       if( transactions.length < $scope.settings.filter.limit ){
         $scope.loadMoreBtn = false;
 
@@ -640,6 +646,7 @@ angular.module('openhimConsoleApp')
           window.open(txUrl, '_blank');
         }else{
           $location.path(path);
+          $location.search({});
         }
       }
     };

--- a/app/scripts/controllers/transactionsAddReqResModal.js
+++ b/app/scripts/controllers/transactionsAddReqResModal.js
@@ -3,14 +3,15 @@
 /* global returnContentType:false */
 
 angular.module('openhimConsoleApp')
-  .controller('TransactionsAddReqResModalCtrl', function ($scope, $modal, $modalInstance, record) {
+  .controller('TransactionsAddReqResModalCtrl', function ($scope, $modal, $modalInstance, record, route) {
 
     $scope.record = record;
+    $scope.route = route; // optional
     $scope.viewFullBody = false;
     $scope.viewFullBodyType = null;
     $scope.viewFullBodyContent = null;
     $scope.fullBodyTransformLang = null;
-    
+
     // transform request body with indentation/formatting
     if( record.request && record.request.body ){
       if( record.request.headers && returnContentType( record.request.headers ) ){
@@ -28,7 +29,7 @@ angular.module('openhimConsoleApp')
         $scope.responseTransformLang = responseTransform.lang;
       }
     }
-    
+
 
     $scope.toggleFullView = function (type, bodyContent, contentType) {
 
@@ -46,22 +47,6 @@ angular.module('openhimConsoleApp')
 
     $scope.cancel = function () {
       $modalInstance.dismiss('cancel');
-    };
-
-    /*********************************************************************/
-    /**               Transactions View Route Functions                 **/
-    /*********************************************************************/
-
-    $scope.viewAddReqResDetails = function(record){
-      $modal.open({
-        templateUrl: 'views/transactionsAddReqResModal.html',
-        controller: 'TransactionsAddReqResModalCtrl',
-        resolve: {
-          record: function () {
-            return record;
-          }
-        }
-      });
     };
 
     /*********************************************************************/

--- a/app/scripts/controllers/transactionsBodyModal.js
+++ b/app/scripts/controllers/transactionsBodyModal.js
@@ -12,7 +12,6 @@ angular.module('openhimConsoleApp')
       if ( bodyData.headers && returnContentType( bodyData.headers ) ){
         var bodyTransform = beautifyIndent(returnContentType( bodyData.headers ), bodyData.content);
         $scope.bodyData.content = bodyTransform.content;
-        $scope.bodyTransformLang = bodyTransform.lang;
       }
     }
 

--- a/app/styles/main.css
+++ b/app/styles/main.css
@@ -574,33 +574,6 @@ body {
   margin-bottom: 5px;
 }
 
-/*.panel-heading>.panel-title, .content-box-header .panel-title {
-    float: left;
-    padding-top: 0px;
-}
-
-.panel-heading>.panel-title>*, .content-box-header .panel-title>* {
-    margin: 0;
-}
-
-.panel-heading>.panel-title>span, .content-box-header .panel-title>span {
-    font-weight: normal;
-}
-
-.panel-heading>.panel-options, .content-box-header .panel-options {
-    float: right;
-    padding-right: 15px;
-}
-
-.panel-heading>.panel-options>a, .content-box-header .panel-options>a {
-    margin-top: 10px;
-}
-
-.panel-body {
-  clear:both;
-}*/
-
-
 /* ----- Transactions ----- */
 .transaction-filter-options { width: 100%; display: inline-block; }
 

--- a/app/styles/main.css
+++ b/app/styles/main.css
@@ -574,7 +574,7 @@ body {
   margin-bottom: 5px;
 }
 
-.panel-heading>.panel-title, .content-box-header .panel-title {
+/*.panel-heading>.panel-title, .content-box-header .panel-title {
     float: left;
     padding-top: 0px;
 }
@@ -598,7 +598,7 @@ body {
 
 .panel-body {
   clear:both;
-}
+}*/
 
 
 /* ----- Transactions ----- */
@@ -677,6 +677,10 @@ body {
   color: #036633;
   font-weight: bold;
 }
+
+.transactionsSummary {
+  font-size: 14px;
+}
 /* ----- Transactions ----- */
 
 /*------- Custom CSS Changes ----*/
@@ -706,16 +710,14 @@ body {
 .navbar-nav > li > a { padding-top: 15px; padding-bottom: 15px; }
 .navbar{ margin: 0; min-height: auto; }
 .topMenu{ display: none; }
-.panel-heading { padding: 0; margin-bottom: 10px; display: inline-block; width: 100% ;}
-.panel-body { padding: 0; }
+.dashboard-metrics-box .panel-heading { padding: 0; margin-bottom: 10px; display: inline-block; width: 100% ;}
+.dashboard-metrics-box .panel-body { padding: 0; }
 
 .responsiveTransactionIndexCheckbox label { display: none; }
 .loadMoreBtn { float: right; }
-#no-more-tables table tr th, #no-more-tables table tr td { word-wrap: break-word; max-width: 150px; }
 .transactionsFilterRefreshDiv{ float: right; padding-top: 22px; margin-bottom: 10px; }
 .transactionsFilterRefreshDiv button i{ font-size: 30px; display: block; width: 100% !important; }
 .rerunTransactionsDiv{float: left; margin-bottom: 10px; }
-#no-more-tables .rerunTransactionsTable { border-bottom: 1px solid #dddddd; }
 .form-group-2columns { clear: both; display: inline-block; width: 100%; }
 .form-group-2columns .form-group { width: 47%; }
 .form-group-3columns { clear: both; display: inline-block; width: 100%; }
@@ -803,8 +805,6 @@ body {
 
 .showHideHeadersBtn:hover { cursor: pointer; }
 .showHideNoPadding { padding: 0px !important; float: left; }
-.headerDetailsTD { padding-right: 30px; }
-
 
 
 .failedImportsLink { color: red; }
@@ -1332,4 +1332,21 @@ label { position: relative; }
 
 .logs-filter input[type=checkbox] {
   width: 20px;
+}
+
+.table-borderless td, .table-borderless th {
+  border: 0 !important;
+}
+
+/* Reset bootstrap popover max width */
+.popover {
+  max-width: none;
+}
+
+.sml-margin {
+  margin: 5px;
+}
+
+.subtitle {
+  color: #999999;
 }

--- a/app/views/auditDetails.html
+++ b/app/views/auditDetails.html
@@ -23,13 +23,13 @@
 
         <div class="panel-body" ng-show="auditDetails">
 
-          <div style="  display: inline-block; width: 100%;">
-            <button class="btn btn-primary" style="margin: 0px 0px 20px 0px; float: right;" ng-click="viewContentDetails('Raw Audit Message', auditDetails.rawMessage)">View Raw Audit Message</button>  
+          <div style="display: inline-block; width: 100%;">
+            <button class="btn btn-primary pull-right" style="margin: 0px 0px 20px 0px;" ng-click="viewContentDetails('Raw Audit Message', auditDetails.rawMessage)">View Raw Audit Message</button>
           </div>
-          
+
           <div class="panel panel-primary">
             <div class="panel-heading">
-              <h3 class="panel-title" style="margin: 10px; font-size: 20px;">Event </h3>
+              <h3 class="panel-title">Event </h3>
             </div>
             <div class="panel-body">
               <div class="audit-info-box" ng-if="auditDetails.eventIdentification.eventDateTime">
@@ -51,7 +51,7 @@
 
           <div class="panel panel-warning">
             <div class="panel-heading">
-              <h3 class="panel-title" style="margin: 10px; font-size: 20px;">Audit Source </h3>
+              <h3 class="panel-title">Audit Source </h3>
             </div>
             <div class="panel-body">
               <div class="audit-info-box" ng-if="auditDetails.auditSourceIdentification.auditSourceID">
@@ -68,7 +68,7 @@
 
           <div class="panel panel-info">
             <div class="panel-heading">
-              <h3 class="panel-title" style="margin: 10px; font-size: 20px;">Active Participant </h3>
+              <h3 class="panel-title">Active Participant </h3>
             </div>
 
             <div class="panel-body">
@@ -95,7 +95,7 @@
 
           <div class="panel panel-success">
             <div class="panel-heading">
-              <h3 class="panel-title" style="margin: 10px; font-size: 20px;">Participant Object </h3>
+              <h3 class="panel-title">Participant Object </h3>
             </div>
             <div class="panel-body">
               <div class="auditRepeatBox" ng-repeat="participantObjectIdentification in auditDetails.participantObjectIdentification">
@@ -118,7 +118,7 @@
                 </div>
                 <div class="audit-info-box" ng-if="participantObjectIdentification.participantObjectQuery">
                   Object Query <br />
-                  <button class="btn btn-primary" style="  padding: 3px 5px; font-size: 12px;" ng-click="viewContentDetails('Object Query', participantObjectIdentification.participantObjectQuery)">Click to view Object Query</button>
+                  <button class="btn btn-primary" style="padding: 3px 5px; font-size: 12px;" ng-click="viewContentDetails('Object Query', participantObjectIdentification.participantObjectQuery)">Click to view Object Query</button>
                 </div>
               </div>
             </div>

--- a/app/views/transactionDetails.html
+++ b/app/views/transactionDetails.html
@@ -119,10 +119,13 @@
                 </div>
                 <div class="panel-body">
 
-                  <h4><span class="label label-default">{{transactionDetails.request.method}}</span>{{ ' ' + transactionDetails.request.host + ':' + transactionDetails.request.port + transactionDetails.request.path + '?' + transactionDetails.request.querystring}}</h4>
+                  <h4>
+                    <span class="label label-default" ng-if="channel.type === 'http'">{{transactionDetails.request.method}}</span>
+                    <span class="label label-danger" ng-if="channel.type !== 'http'">{{channel.type | uppercase}}</span>
+                    <span>{{ transactionDetails.request.host }}</span><span ng-if="transactionDetails.request.port">{{ ':' + transactionDetails.request.port }}</span><span ng-if="channel.type === 'http'">{{ transactionDetails.request.path }}</span><span ng-if="transactionDetails.request.querystring && channel.type === 'http'">{{ '?' + transactionDetails.request.querystring }}</span>
                   <h6 class="subtitle"><em>Received at {{transactionDetails.request.timestamp | date:'yyyy-MM-dd HH:mm:ss.sss Z'}}</em></h6>
 
-                  <a data-toggle="collapse" href="#req-headers-table">Show Headers <i class="glyphicon glyphicon-chevron-down"></i></a>
+                  <a data-toggle="collapse" href="#req-headers-table" ng-if="channel.type === 'http'">Show Headers <i class="glyphicon glyphicon-chevron-down"></i></a>
                   <div id="req-headers-table" class="panel panel-default collapse">
                     <div class="panel-body">
                       <table class="table-condensed table-borderless">
@@ -151,7 +154,8 @@
                 </div>
                 <div class="panel-body">
 
-                  <h4>Status code
+                  <span class="label label-danger" ng-if="channel.type !== 'http'">{{channel.type | uppercase}}</span>
+                  <h4 ng-if="channel.type === 'http'">Status code
                     <span ng-if="transactionDetails.response.status >= 200 && transactionDetails.response.status < 300" class="label label-success">{{transactionDetails.response.status}}</span>
                     <span ng-if="transactionDetails.response.status >= 300 && transactionDetails.response.status < 400" class="label label-primary">{{transactionDetails.response.status}}</span>
                     <span ng-if="transactionDetails.response.status >= 400 && transactionDetails.response.status < 500" class="label label-warning">{{transactionDetails.response.status}}</span>
@@ -159,7 +163,7 @@
                   </h4>
                   <h6 class="subtitle"><em>Received at {{transactionDetails.response.timestamp | date:'yyyy-MM-dd HH:mm:ss.sss Z'}}</em></h6>
 
-                  <a data-toggle="collapse" href="#res-headers-table">Show Headers <i class="glyphicon glyphicon-chevron-down"></i></a>
+                  <a data-toggle="collapse" href="#res-headers-table" ng-if="channel.type === 'http'">Show Headers <i class="glyphicon glyphicon-chevron-down"></i></a>
                   <div id="res-headers-table" class="panel panel-default collapse">
                     <div class="panel-body">
                       <table class="table-condensed table-borderless">
@@ -198,9 +202,13 @@
                       </tr>
                     </thead>
                     <tbody>
-                      <tr class="table-list" ng-repeat="route in transactionDetails.routes" ng-click="viewAddReqResDetails(route)">
+                      <tr class="table-list" ng-repeat="route in transactionDetails.routes" ng-click="viewAddReqResDetails(route, routeDefs[route.name])">
                         <td data-title="Route">{{ route.name }}</td>
-                        <td data-title="URL">{{ route.request.method + ' ' + route.request.host + ':' + route.request.port + '/' + route.request.path + '?' + route.request.querystring }}</td>
+                        <td data-title="URL">
+                          <span class="label label-default" ng-if="routeDefs[route.name].type === 'http'">{{route.request.method}}</span>
+                          <span class="label label-danger" ng-if="routeDefs[route.name].type !== 'http'">{{routeDefs[route.name].type | uppercase}}</span>
+                          <span>{{ route.request.host }}</span><span ng-if="route.request.port">{{ ':' + route.request.port }}</span><span ng-if="routeDefs[route.name].type === 'http'">{{ route.request.path }}</span><span ng-if="route.request.querystring && routeDefs[route.name].type === 'http'">{{ '?' + route.request.querystring }}</span>
+                        </td>
                         <td data-title="Status">{{ route.response.status }}</td>
                         <td data-title="Response Time">{{ route.response.timestamp | date:'yyyy-MM-dd HH:mm:ss Z' }}</td>
                       </tr>
@@ -228,7 +236,10 @@
                     <tbody>
                       <tr class="table-list" ng-repeat="orchestration in transactionDetails.orchestrations" ng-click="viewAddReqResDetails(orchestration)">
                         <td data-title="Name">{{ orchestration.name }}</td>
-                        <td data-title="URL">{{ orchestration.request.method + ' ' + orchestration.request.host + ':' + orchestration.request.port + '/' + orchestration.request.path + '?' + orchestration.request.querystring }}</td>
+                        <td data-title="URL">
+                          <span class="label label-default">{{orchestration.request.method}}</span>
+                          <span>{{ orchestration.request.host }}</span><span ng-if="orchestration.request.port">{{ ':' + orchestration.request.port }}</span><span>{{ orchestration.request.path }}</span><span ng-if="orchestration.request.querystring">{{ '?' + orchestration.request.querystring }}</span>
+                        </td>
                         <td data-title="Status">{{ orchestration.response.status }}</td>
                         <td data-title="Response Time">{{ orchestration.response.timestamp | date:'yyyy-MM-dd HH:mm:ss Z' }}</td>
                       </tr>

--- a/app/views/transactionDetails.html
+++ b/app/views/transactionDetails.html
@@ -125,8 +125,7 @@
 
                   <div ng-if="transactionDetails.request.body" style="display: inline-block; width: 100%; margin-top: 15px;">
                     <h4>Request body</h4>
-                    <div ng-if="requestTransformLang" class="hljsFormat" hljs source="transactionDetails.request.body" language="{{requestTransformLang}}"></div>
-                    <div ng-if="!requestTransformLang" class="hljsFormatNone">{{transactionDetails.request.body}}</div>
+                    <div class="hljsFormat" hljs source="transactionDetails.request.body"></div>
                     <button style="margin-top: 10px;" class="btn btn-primary pull-right" ng-click="viewBodyDetails('Request', transactionDetails.request.body, transactionDetails.request.headers);">View Full Request Body</button>
                   </div>
                 </div>
@@ -163,8 +162,7 @@
 
                   <div ng-if="transactionDetails.response.body" style="display: inline-block; width: 100%; margin-top: 15px;">
                     <h4>Response body</h4>
-                    <div ng-if="responseTransformLang" class="hljsFormat" hljs source="transactionDetails.response.body" language="{{responseTransformLang}}"></div>
-                    <div ng-if="!responseTransformLang" class="hljsFormatNone">{{transactionDetails.response.body}}</div>
+                    <div class="hljsFormat" hljs source="transactionDetails.response.body"></div>
                     <button style="margin-top: 10px;" class="btn btn-primary pull-right" ng-click="viewBodyDetails('Response', transactionDetails.response.body, transactionDetails.response.headers);">View Full Response Body</button>
                   </div>
                 </div>
@@ -240,7 +238,7 @@
                 </div>
               </div>
             </div>
-            
+
           </div>
         </div>
       </div>

--- a/app/views/transactionDetails.html
+++ b/app/views/transactionDetails.html
@@ -67,12 +67,15 @@
                 </div>
                 <button id="rerun-popover" type="button" ng-show="childTransactions.length >= 1" class="btn btn-default" data-toggle="popover" data-placement="bottom" data-trigger="focus">Show reruns</button>
                 <button ng-show="transactionDetails.parentID" class="btn btn-default" ng-click="viewTransactionDetails('/transactions/' + transactionDetails.parentID)">View Original Transaction</button>
-                <button class="btn btn-danger" ng-if="rerunAllowed && transactionDetails.canRerun" ng-click="confirmRerunTransactions();">Re-run Transaction</button>
+                <button class="btn btn-danger" ng-disabled="!rerunAllowed || !transactionDetails.canRerun" ng-click="confirmRerunTransactions();">Re-run Transaction</button>
               </div>
 
-              <div class="btn-group sml-margin" role="group">
-                <button type="button" class="btn btn-primary"><i class="glyphicon glyphicon-arrow-left"></i> Prev</button>
-                <button type="button" class="btn btn-primary">Next <i class="glyphicon glyphicon-arrow-right"></i></button>
+              <div class="sml-margin" ng-show="pagingEnabled === true">
+                <div class="btn-group" role="group">
+                  <a href="/#/transactions/{{prev}}" role="button" class="btn btn-primary" ng-disabled="prev === null"><i class="glyphicon glyphicon-arrow-left"></i> Prev</a>
+                  <a href="/#/transactions/{{next}}" role="button" class="btn btn-primary" ng-disabled="next === null">Next <i class="glyphicon glyphicon-arrow-right"></i></a>
+                </div>
+                <p class="transactionsSummary">Number {{txNumber}} of {{txTotal}} transaction in the <a href="#{{currFilterURL}}">current filter</a>.</p>
               </div>
 
               <div id="rerun-table" class="hide">
@@ -88,8 +91,16 @@
                   </thead>
                   <tbody>
                     <tr class="table-list" ng-repeat="childTransaction in childTransactions" ng-click="viewTransactionDetails('/transactions/' + childTransaction._id, $event)">
-                      <td data-title="URL">{{ childTransaction.request.method + ' ' + childTransaction.request.host + ':' + childTransaction.request.port + childTransaction.request.path + childTransaction.request.querystring }}</td>
-                      <td data-title="Status">{{ childTransaction.status }}</td>
+                      <td data-title="URL"><span class="label label-default">{{childTransaction.request.method}}</span>{{ ' ' + childTransaction.request.host + ':' + childTransaction.request.port + childTransaction.request.path + childTransaction.request.querystring }}</td>
+                      <td data-title="Status">
+                        <div>
+                          <span ng-if="childTransaction.status === 'Successful'" class="label label-success">Successful</span>
+                          <span ng-if="childTransaction.status === 'Completed'" class="label label-success">Completed</span>
+                          <span ng-if="childTransaction.status === 'Processing'" class="label label-info">Processing</span>
+                          <span ng-if="childTransaction.status === 'Completed with error(s)'" class="label label-warning">Completed with error(s)</span>
+                          <span ng-if="childTransaction.status === 'Failed'" class="label label-danger">Failed</span>
+                        </div>
+                      </td>
                       <td data-title="Request Time">{{ childTransaction.request.timestamp | date:'yyyy-MM-dd HH:mm:ss.sss Z' }}</td>
                       <td data-title=""><a href="/#/transactions/{{childTransaction._id}}" target="_blank"><i class="glyphicon glyphicon-new-window"></i></a></td>
                     </tr>

--- a/app/views/transactionDetails.html
+++ b/app/views/transactionDetails.html
@@ -2,283 +2,257 @@
   <div class="row">
     <!-- include the sidebar -->
     <div ng-include="'views/sidebar.html'"></div>
+
     <div class="col-md-10">
 
       <div class="content-box-large">
+
+        <!-- Heading -->
         <div class="panel-heading">
-          <div class="panel-title" style="float: inherit">
+          <div class="panel-title">
             <h2>
               <i ng-if="transactionDetails.childIDs.length == 0" class="glyphicon glyphicon-tasks"></i>
               <i ng-if="transactionDetails.childIDs.length > 0" class="glyphicon glyphicon-repeat"></i>
-              &nbsp;Transaction #{{transactionDetails._id}}</h2>
+              &nbsp;Transaction details</h2>
           </div>
         </div>
 
         <!-- Transaction Alerts -->
         <alert ng-repeat="alert in alerts.server" type="alert.type">{{alert.msg}}</alert>
-        <!-- Server Alerts -->
 
+        <!-- Transaction details -->
         <div class="panel-body" ng-show="transactionDetails">
-          <!-- div to hold any child transactions if any -->
-          <div class="rerunTransactionsDiv">
-            <button ng-if="childTransactions.length >= 1" class="btn btn-primary" data-toggle="collapse" data-target="#no-more-tables">View all rerun transactions</button> 
-            <button ng-if="transactionDetails.parentID" class="btn btn-primary" ng-click='viewTransactionDetails("/transactions/" + transactionDetails.parentID)'>View Original Transaction</button>
-          </div>
 
-          <div class="buttons-container">
-            <button class="btn btn-primary" ng-if="rerunAllowed && transactionDetails.canRerun" ng-click="confirmRerunTransactions();">Re-run Transaction</button>
-            <div style="font-size: 16px; display: block;" ng-if="!transactionDetails.canRerun" class="label label-danger">
-              RERUN NOT POSSIBLE!<br />
-              Method is either POST/PUT/PATCH and Request Body not saved!
-            </div>
-          </div>
-
-          <div id="no-more-tables" class="collapse" style="width: 100%; clear: both;">
-            <!-- Table with all the transaction logs -->
-            <table class="table table-striped rerunTransactionsTable">
-              <thead>
+          <div class="row">
+            <!-- summary details, left -->
+            <div class="col-md-6">
+              <table class="table-condensed table-borderless transactionsSummary">
                 <tr>
-                  <th>#</th>
-                  <th>HTTP Method</th>
-                  <th>Host</th>
-                  <th>Port</th>
-                  <th>Path</th>
-                  <th>Request Params</th>
+                  <th>ID</th>
+                  <td>{{transactionDetails._id}}</td>
+                </tr>
+                <tr>
                   <th>Status</th>
-                  <th>Request Time</th>
+                  <td>
+                    <div>
+                      <span ng-if="transactionDetails.status === 'Successful'" class="label label-success">Successful</span>
+                      <span ng-if="transactionDetails.status === 'Completed'" class="label label-success">Completed</span>
+                      <span ng-if="transactionDetails.status === 'Processing'" class="label label-info">Processing</span>
+                      <span ng-if="transactionDetails.status === 'Completed with error(s)'" class="label label-warning">Completed with error(s)</span>
+                      <span ng-if="transactionDetails.status === 'Failed'" class="label label-danger">Failed</span>
+                    </div>
+                  </td>
                 </tr>
-              </thead>
-              <tbody>
-                <tr class="table-list" ng-repeat="childTransaction in childTransactions" ng-click='viewTransactionDetails("/transactions/" + childTransaction._id, $event)'>
-                  <td data-title="# {{ $index +1 }}" class="responsiveTransactionIndexCheckbox"><span>{{ $index +1 }}</span></td>
-                  <td data-title="HTTP Method">{{ childTransaction.request.method }}</td>
-                  <td data-title="Host">{{ childTransaction.request.host }}</td>
-                  <td data-title="Port">{{ childTransaction.request.port }}</td>
-                  <td data-title="Path">{{ childTransaction.request.path }}</td>
-                  <td data-title="Request Params">{{ childTransaction.request.querystring }}</td>
-                  <td data-title="Status">{{ childTransaction.status }}</td>
-                  <td data-title="Request Time">{{ childTransaction.request.timestamp | date:'yyyy-MM-dd HH:mm:ss Z' }}</td>
+                <tr>
+                  <th>Channel</th>
+                  <td>{{channel.name}}</td>
                 </tr>
-              </tbody>
-            </table>
-          </div>
-
-          <div class="transaction-detail-container">
-            <div class="data-group">
-              <label>ID: </label>
-              <div class="data-value">{{transactionDetails._id}}</div>
+                <tr>
+                  <th>Authorized Client</th>
+                  <td ng-if="client">{{client.name}}</td>
+                </tr>
+                <tr>
+                  <th>Duration</th>
+                  <td ng-if="transactionDetails.transactionTime">{{transactionDetails.transactionTime}}</td>
+                </tr>
+              </table>
             </div>
-            <div class="data-group">
-              <label>Status: </label>
-              <div class="data-value">
-                <span ng-if="transactionDetails.status === 'Successful'" class="label label-success">Successful</span>
-                <span ng-if="transactionDetails.status === 'Completed'" class="label label-success">Completed</span>
-                <span ng-if="transactionDetails.status === 'Processing'" class="label label-info">Processing</span>
-                <span ng-if="transactionDetails.status === 'Completed with error(s)'" class="label label-warning">Completed with error(s)</span>
-                <span ng-if="transactionDetails.status === 'Failed'" class="label label-danger">Failed</span>
+
+            <!-- control buttons with rerun tx list, right -->
+            <div class="col-md-6">
+              <div class="sml-margin">
+                <div class="alert alert-danger alert-dismissible" ng-if="!transactionDetails.canRerun" role="alert">
+                  <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                  <strong>Not able to rerun this transaction!</strong> The HTTP method is either POST, PUT or PATCH and request body was not saved.
+                </div>
+                <button id="rerun-popover" type="button" ng-show="childTransactions.length >= 1" class="btn btn-default" data-toggle="popover" data-placement="bottom" data-trigger="focus">Show reruns</button>
+                <button ng-show="transactionDetails.parentID" class="btn btn-default" ng-click="viewTransactionDetails('/transactions/' + transactionDetails.parentID)">View Original Transaction</button>
+                <button class="btn btn-danger" ng-if="rerunAllowed && transactionDetails.canRerun" ng-click="confirmRerunTransactions();">Re-run Transaction</button>
+              </div>
+
+              <div class="btn-group sml-margin" role="group">
+                <button type="button" class="btn btn-primary"><i class="glyphicon glyphicon-arrow-left"></i> Prev</button>
+                <button type="button" class="btn btn-primary">Next <i class="glyphicon glyphicon-arrow-right"></i></button>
+              </div>
+
+              <div id="rerun-table" class="hide">
+                <!-- Table with all rerun the transaction logs -->
+                <table class="table table-striped">
+                  <thead>
+                    <tr>
+                      <th>URL</th>
+                      <th>Status</th>
+                      <th>Request Time</th>
+                      <th></th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr class="table-list" ng-repeat="childTransaction in childTransactions" ng-click="viewTransactionDetails('/transactions/' + childTransaction._id, $event)">
+                      <td data-title="URL">{{ childTransaction.request.method + ' ' + childTransaction.request.host + ':' + childTransaction.request.port + childTransaction.request.path + childTransaction.request.querystring }}</td>
+                      <td data-title="Status">{{ childTransaction.status }}</td>
+                      <td data-title="Request Time">{{ childTransaction.request.timestamp | date:'yyyy-MM-dd HH:mm:ss.sss Z' }}</td>
+                      <td data-title=""><a href="/#/transactions/{{childTransaction._id}}" target="_blank"><i class="glyphicon glyphicon-new-window"></i></a></td>
+                    </tr>
+                  </tbody>
+                </table>
               </div>
             </div>
-            <div class="data-group">
-              <label>Channel: </label>
-              <div class="data-value">{{channel.name}}</div>
-            </div>
-            <div class="data-group" ng-if="client">
-              <label>Authorized Client: </label>
-              <div class="data-value">{{client.name}}</div>
-            </div>
-            <div class="data-group" ng-if="transactionDetails.transactionTime">
-              <label>Transaction Time: </label>
-              <div class="data-value">{{transactionDetails.transactionTime}}</div>
-            </div>
+          </div>
 
-            <tabset class="transaction_details_tabset" justified="false" style="  margin: 20px 0px 0px 0px; display: inline-block; width: 100%;">
-              <tab>
-                <tab-heading style="font-weight: bold;">Request</tab-heading>
+          <div class="row">
+            <!-- Request, left -->
+            <div class="col-md-6">
+              <div class="panel panel-default sml-margin transaction-req-res-height">
+                <div class="panel-heading">
+                  <h3 class="panel-title">Request</h3>
+                </div>
+                <div class="panel-body">
 
-                <div style="width: 100%; display: inline-block; background: #fff; padding: 10px;">
-                  
-                  <div class="data-group left-indent">
-                    <label>Host: </label>
-                    <div class="data-value">{{transactionDetails.request.host}}</div>
-                  </div>
-                  <div class="data-group left-indent">
-                    <label>Port: </label>
-                    <div class="data-value">{{transactionDetails.request.port}}</div>
-                  </div>
-                  <div class="data-group left-indent">
-                    <label>Path: </label>
-                    <div class="data-value">{{transactionDetails.request.path}}</div>
-                  </div>
-                  <div class="data-group left-indent">
-                    <label>Parameters: </label>
-                    <div class="data-value">{{transactionDetails.request.querystring}}</div>
-                  </div>
-                  <div class="data-group left-indent">
-                    <label>HTTP Method: </label>
-                    <div class="data-value">{{transactionDetails.request.method}}</div>
-                  </div>
-                  <div class="data-group left-indent">
-                    <label>Timestamp: </label>
-                    <div class="data-value">{{transactionDetails.request.timestamp | date:'yyyy-MM-dd HH:mm:ss Z'}}</div>
-                  </div>
-                  <div class="data-group left-indent" ng-if="transactionDetails.request.headers">
-                    <label>Headers: </label>
-                    <div class="data-value showHideNoPadding">
-                      <table class=" collapse" id="requestHeaders{{transactionDetails._id}}">
+                  <h4><span class="label label-default">{{transactionDetails.request.method}}</span>{{ ' ' + transactionDetails.request.host + ':' + transactionDetails.request.port + transactionDetails.request.path + '?' + transactionDetails.request.querystring}}</h4>
+                  <h6 class="subtitle"><em>Received at {{transactionDetails.request.timestamp | date:'yyyy-MM-dd HH:mm:ss.sss Z'}}</em></h6>
+
+                  <a data-toggle="collapse" href="#req-headers-table">Show Headers <i class="glyphicon glyphicon-chevron-down"></i></a>
+                  <div id="req-headers-table" class="panel panel-default collapse">
+                    <div class="panel-body">
+                      <table class="table-condensed table-borderless">
                         <tr ng-repeat="(key, property) in transactionDetails.request.headers">
-                          <td class="headerDetailsTD">{{key}}: </td>
-                          <td><strong>{{property}}</strong></td>
+                          <th>{{key}}: </th>
+                          <td>{{property}}</td>
                         </tr>
                       </table>
-                      <a class="showHideHeadersBtn" data-toggle="collapse" data-target="#requestHeaders{{transactionDetails._id}}">Show/Hide Headers</a>            
                     </div>
                   </div>
 
                   <div ng-if="transactionDetails.request.body" style="display: inline-block; width: 100%; margin-top: 15px;">
-                    <label>Body: </label>
-                    <div class="data-group">
-                      <div class="data-value">
-                        <div ng-if="requestTransformLang" class="hljsFormat" hljs source="transactionDetails.request.body" language="{{requestTransformLang}}"></div>
-                        <div ng-if="!requestTransformLang" class="hljsFormatNone">{{transactionDetails.request.body}}</div>
-                        <button style="float: right; margin-top: 10px;" class="btn btn-primary" ng-click="viewBodyDetails('Request', transactionDetails.request.body, transactionDetails.request.headers);">View Full Request Body</button>
-                      </div>
-                    </div>
+                    <h4>Request body</h4>
+                    <div ng-if="requestTransformLang" class="hljsFormat" hljs source="transactionDetails.request.body" language="{{requestTransformLang}}"></div>
+                    <div ng-if="!requestTransformLang" class="hljsFormatNone">{{transactionDetails.request.body}}</div>
+                    <button style="margin-top: 10px;" class="btn btn-primary pull-right" ng-click="viewBodyDetails('Request', transactionDetails.request.body, transactionDetails.request.headers);">View Full Request Body</button>
                   </div>
                 </div>
-              </tab>
+              </div>
+            </div>
 
-              <tab ng-if="transactionDetails.response">
-                <tab-heading style="font-weight: bold;">Response</tab-heading>
-                <div>
+            <!-- Response, right -->
+            <div class="col-md-6" ng-if="transactionDetails.response">
+              <div class="panel panel-default sml-margin transaction-req-res-height">
+                <div class="panel-heading">
+                  <h3 class="panel-title">Response</h3>
+                </div>
+                <div class="panel-body">
 
-                  <div style="width: 100%; display: inline-block; background: #fff; padding: 10px;">
-                    <div class="data-group left-indent">
-                      <label>Status: </label>
-                      <div class="data-value">{{transactionDetails.response.status}}</div>
+                  <h4>Status code
+                    <span ng-if="transactionDetails.response.status >= 200 && transactionDetails.response.status < 300" class="label label-success">{{transactionDetails.response.status}}</span>
+                    <span ng-if="transactionDetails.response.status >= 300 && transactionDetails.response.status < 400" class="label label-primary">{{transactionDetails.response.status}}</span>
+                    <span ng-if="transactionDetails.response.status >= 400 && transactionDetails.response.status < 500" class="label label-warning">{{transactionDetails.response.status}}</span>
+                    <span ng-if="transactionDetails.response.status >= 500 && transactionDetails.response.status < 600" class="label label-danger">{{transactionDetails.response.status}}</span>
+                  </h4>
+                  <h6 class="subtitle"><em>Received at {{transactionDetails.response.timestamp | date:'yyyy-MM-dd HH:mm:ss.sss Z'}}</em></h6>
+
+                  <a data-toggle="collapse" href="#res-headers-table">Show Headers <i class="glyphicon glyphicon-chevron-down"></i></a>
+                  <div id="res-headers-table" class="panel panel-default collapse">
+                    <div class="panel-body">
+                      <table class="table-condensed table-borderless">
+                        <tr ng-repeat="(key, property) in transactionDetails.response.headers">
+                          <th>{{key}}: </th>
+                          <td>{{property}}</td>
+                        </tr>
+                      </table>
                     </div>
-                    <div class="data-group left-indent">
-                      <label>Timestamp: </label>
-                      <div class="data-value">{{transactionDetails.response.timestamp | date:'yyyy-MM-dd HH:mm:ss Z'}}</div>
-                    </div>
-                    <div class="data-group left-indent" ng-if="transactionDetails.response.headers">
-                      <label>Headers: </label>
-                      <div class="data-value showHideNoPadding">
-                        <table class=" collapse" id="responseHeaders{{transactionDetails._id}}">
-                          <tr ng-repeat="(key, property) in transactionDetails.response.headers">
-                            <td class="headerDetailsTD">{{key}}: </td>
-                            <td><strong>{{property}}</strong></td>
-                          </tr>
-                        </table>
-                        <a class="showHideHeadersBtn" data-toggle="collapse" data-target="#responseHeaders{{transactionDetails._id}}">Show/Hide Headers</a>            
-                      </div>
-                    </div>
-
-                    <div ng-if="transactionDetails.response.body" style="display: inline-block; width: 100%; margin-top: 15px;">
-                      <label>Body:</label>
-                      <div class="data-group">
-                        <div class="data-value">
-                          <div ng-if="responseTransformLang" class="hljsFormat" hljs source="transactionDetails.response.body" language="{{responseTransformLang}}"></div>
-                          <div ng-if="!responseTransformLang" class="hljsFormatNone">{{transactionDetails.response.body}}</div>
-                          <button style="float: right; margin-top: 10px;" class="btn btn-primary" ng-click="viewBodyDetails('Response', transactionDetails.response.body, transactionDetails.response.headers);">View Full Response Body</button>
-                        </div>
-                      </div>
-                    </div>
-
-
-
-                    <div ng-show="transactionDetails.routes" style="display: inline-block; width: 100%">
-                      <label>Routes: </label>
-                      <div id="no-more-tables" class="data-group">
-                        <div class="data-value">
-                          <!-- Table with all the Routes logs -->
-                          <table class="table table-striped">
-                            <thead>
-                              <tr>
-                                <th>Route</th>
-                                <th>Method</th>
-                                <th>Host</th>                      
-                                <th>Port</th>                      
-                                <th>Path</th>                      
-                                <th>Request Params</th>
-                                <th>Status</th>
-                                <th>Response Time</th>
-                              </tr>
-                            </thead>
-                            <tbody>
-                              <tr class="table-list" ng-repeat="route in transactionDetails.routes" ng-click='viewAddReqResDetails(route)'>
-                                <td data-title="Route">{{ route.name }}</td>
-                                <td data-title="Method">{{ route.request.method }}</td>
-                                <td data-title="Host">{{ route.request.host }}</td>
-                                <td data-title="Port">{{ route.request.port }}</td>
-                                <td data-title="Path">{{ route.request.path }}</td>
-                                <td data-title="Request Params">{{ route.request.querystring }}</td>
-                                <td data-title="Status">{{ route.response.status }}</td>
-                                <td data-title="Response Time">{{ route.response.timestamp | date:'yyyy-MM-dd HH:mm:ss Z' }}</td>
-                              </tr>
-                            </tbody>
-                          </table>
-                        </div>
-                      </div>
-                    </div>
-
-                    <div ng-show="transactionDetails.orchestrations" style="display: inline-block; width: 100%">
-                      <label>Orchestrations: </label>
-                      <div id="no-more-tables" class="data-group">
-                        <div class="data-value">
-                          <!-- Table with all the orchestrations -->
-                          <table class="table table-striped">
-                            <thead>
-                              <tr>
-                                <th>Name</th>
-                                <th>Method</th>
-                                <th>Host</th>                      
-                                <th>Port</th>                      
-                                <th>Path</th>                      
-                                <th>Request Params</th>
-                                <th>Status</th>
-                                <th>Response Time</th>
-                              </tr>
-                            </thead>
-                            <tbody>
-                              <tr class="table-list" ng-repeat="orchestration in transactionDetails.orchestrations" ng-click='viewAddReqResDetails(orchestration)'>
-                                <td data-title="Name">{{ orchestration.name }}</td>
-                                <td data-title="Method">{{ orchestration.request.method }}</td>
-                                <td data-title="Host">{{ orchestration.request.host }}</td>
-                                <td data-title="Port">{{ orchestration.request.port }}</td>
-                                <td data-title="Path">{{ orchestration.request.path }}</td>
-                                <td data-title="Request Params">{{ orchestration.request.querystring }}</td>
-                                <td data-title="Status">{{ orchestration.response.status }}</td>
-                                <td data-title="Response Time">{{ orchestration.response.timestamp | date:'yyyy-MM-dd HH:mm:ss Z' }}</td>
-                              </tr>
-                            </tbody>
-                          </table>
-                        </div>
-                      </div>
-                    </div>
-
-
-                    <div ng-show="transactionDetails.properties" style="display: inline-block; width: 100%">
-                      <label>Properties: </label>
-                      <div class="data-group">
-                        <div class="data-value">
-                          <div class="content-box-large default-labels-box" style="margin-right: 10px;" ng-repeat="(key, property) in transactionDetails.properties">
-                            {{key}}: <strong>{{property}}</strong>
-                          </div>  
-                        </div>
-                      </div>
-                    </div>
-
-
-
                   </div>
 
+                  <div ng-if="transactionDetails.response.body" style="display: inline-block; width: 100%; margin-top: 15px;">
+                    <h4>Response body</h4>
+                    <div ng-if="responseTransformLang" class="hljsFormat" hljs source="transactionDetails.response.body" language="{{responseTransformLang}}"></div>
+                    <div ng-if="!responseTransformLang" class="hljsFormatNone">{{transactionDetails.response.body}}</div>
+                    <button style="margin-top: 10px;" class="btn btn-primary pull-right" ng-click="viewBodyDetails('Response', transactionDetails.response.body, transactionDetails.response.headers);">View Full Response Body</button>
+                  </div>
                 </div>
-              </tab>
-            </tabset>
+              </div>
+            </div>
+          </div>
+
+          <div class="row">
+            <!-- Routes -->
+            <div ng-show="transactionDetails.routes">
+              <h3>Non-primary routes</h3>
+              <div class="data-group no-more-tables">
+                <div class="data-value">
+                  <!-- Table with all the Routes logs -->
+                  <table class="table table-striped">
+                    <thead>
+                      <tr>
+                        <th>Route</th>
+                        <th>URL</th>
+                        <th>Status</th>
+                        <th>Response Time</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      <tr class="table-list" ng-repeat="route in transactionDetails.routes" ng-click="viewAddReqResDetails(route)">
+                        <td data-title="Route">{{ route.name }}</td>
+                        <td data-title="URL">{{ route.request.method + ' ' + route.request.host + ':' + route.request.port + '/' + route.request.path + '?' + route.request.querystring }}</td>
+                        <td data-title="Status">{{ route.response.status }}</td>
+                        <td data-title="Response Time">{{ route.response.timestamp | date:'yyyy-MM-dd HH:mm:ss Z' }}</td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            </div>
+
+            <!-- Orchestrations -->
+            <div ng-show="transactionDetails.orchestrations">
+              <h3>Orchestrations</h3>
+              <div class="data-group no-more-tables">
+                <div class="data-value">
+                  <!-- Table with all the orchestrations -->
+                  <table class="table table-striped">
+                    <thead>
+                      <tr>
+                        <th>Name</th>
+                        <th>URL</th>
+                        <th>Status</th>
+                        <th>Response Time</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      <tr class="table-list" ng-repeat="orchestration in transactionDetails.orchestrations" ng-click="viewAddReqResDetails(orchestration)">
+                        <td data-title="Name">{{ orchestration.name }}</td>
+                        <td data-title="URL">{{ orchestration.request.method + ' ' + orchestration.request.host + ':' + orchestration.request.port + '/' + orchestration.request.path + '?' + orchestration.request.querystring }}</td>
+                        <td data-title="Status">{{ orchestration.response.status }}</td>
+                        <td data-title="Response Time">{{ orchestration.response.timestamp | date:'yyyy-MM-dd HH:mm:ss Z' }}</td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            </div>
+
+            <!-- Properties -->
+            <div ng-show="transactionDetails.properties">
+              <h3>Properties</h3>
+              <div class="data-group">
+                <div class="data-value">
+                  <div class="content-box-large default-labels-box" style="margin-right: 10px;" ng-repeat="(key, property) in transactionDetails.properties">
+                    {{key}}: <strong>{{property}}</strong>
+                  </div>
+                </div>
+              </div>
+            </div>
             
-          </div>          
+          </div>
         </div>
       </div>
     </div>
   </div>
 </div>
+
+<script type="text/javascript">
+  $(function () {
+    $('#rerun-popover').popover({
+      content: function() { return $('#rerun-table').html() },
+      html: true
+    })
+  })
+</script>

--- a/app/views/transactionsAddReqResModal.html
+++ b/app/views/transactionsAddReqResModal.html
@@ -5,159 +5,106 @@
 </div>
 
 <div class="modal-body" style="width: 100%; display: inline-block;">
-  <tabset ng-show="!viewFullBody" class="transaction_details_tabset route-detail-container" justified="false" style="  margin: 0px; display: inline-block; width: 100%;">
-    <tab>
-      <tab-heading>Request</tab-heading>
-      <div style="width: 100%; display: inline-block; background: #fff; padding: 10px;">
-        <div class="data-group left-indent">
-          <label>Host: </label>
-          <div class="data-value">{{record.request.host}}</div>
-        </div>
-        <div class="data-group left-indent">
-          <label>Port: </label>
-          <div class="data-value">{{record.request.port}}</div>
-        </div>
-        <div class="data-group left-indent">
-          <label>Path: </label>
-          <div class="data-value">{{record.request.path}}</div>
-        </div>
-        <div class="data-group left-indent">
-          <label>Parameters: </label>
-          <div class="data-value">{{record.request.querystring}}</div>
-        </div>
-        <div class="data-group left-indent">
-          <label>HTTP Method: </label>
-          <div class="data-value">{{record.request.method}}</div>
-        </div>
-        <div class="data-group left-indent">
-          <label>Timestamp: </label>
-          <div class="data-value">{{record.request.timestamp | date:'yyyy-MM-dd HH:mm:ss Z'}}</div>
-        </div>
-        <div class="data-group left-indent" ng-if="record.request.headers">
-          <label>Headers: </label>
-          <div class="data-value showHideNoPadding">
-            <table class=" collapse" id="requestHeaders{{record._id}}">
-              <tr ng-repeat="(key, property) in record.request.headers">
-                <td class="headerDetailsTD">{{key}}: </td>
-                <td><strong>{{property}}</strong></td>
-              </tr>
-            </table>
-            <a class="showHideHeadersBtn" data-toggle="collapse" data-target="#requestHeaders{{record._id}}">Show/Hide Headers</a>            
-          </div>
-        </div>
 
-        <div ng-if="record.request.body" style="display: inline-block; width: 100%">
-          <label class="data-group"><label>Body: </label></label>
-          <div class="data-group">
-            <div class="data-value">
-              <div class="data-value">
-                <div ng-if="requestTransformLang" class="hljsFormat" hljs source="record.request.body" language="{{requestTransformLang}}" style="max-height: 350px;"></div>
-                <div ng-if="!requestTransformLang" class="hljsFormatNone" style="max-height: 350px;">{{record.request.body}}</div>
-              </div>
-              <!-- show only if record has request body -->
-              <button type="button" class="btn btn-primary" ng-click="toggleFullView('Request', record.request.body, requestTransformLang)" style="float: right; margin-top: 10px;">
-                <span ng-show="!viewFullBody">View Full Request Body</span>
-              </button>
+  <div class="row" ng-show="!viewFullBody">
+    <!-- Request, left -->
+    <div class="col-md-6">
+      <div class="panel panel-default sml-margin transaction-req-res-height">
+        <div class="panel-heading">
+          <h3 class="panel-title">Request</h3>
+        </div>
+        <div class="panel-body">
+
+          <h4>
+            <div ng-if="route">
+              <span class="label label-default" ng-if="route.type === 'http'">{{record.request.method}}</span>
+              <span class="label label-danger" ng-if="route.type !== 'http'">{{route.type | uppercase}}</span>
+              <span>{{ record.request.host }}</span><span ng-if="record.request.port">{{ ':' + record.request.port }}</span><span ng-if="route.type === 'http'">{{ record.request.path }}</span><span ng-if="record.request.querystring && route.type === 'http'">{{ '?' + record.request.querystring }}</span>
             </div>
-          </div>
-        </div>
-      </div>
-    </tab>
+            <!-- Assume its HTTP, can't do much else -->
+            <div ng-if="!route">
+              <span class="label label-default">{{record.request.method}}</span>
+              <span>{{ record.request.host }}</span><span ng-if="record.request.port">{{ ':' + record.request.port }}</span><span>{{ record.request.path }}</span><span ng-if="record.request.querystring">{{ '?' + record.request.querystring }}</span>
+            </div>
+          <h6 class="subtitle"><em>Received at {{record.request.timestamp | date:'yyyy-MM-dd HH:mm:ss.sss Z'}}</em></h6>
 
-    <tab>
-      <tab-heading>Response</tab-heading>
-      <div>
-        <div style="width: 100%; display: inline-block; background: #fff; padding: 10px;">
-          <div class="data-group left-indent">
-            <label>Status: </label>
-            <div class="data-value">{{record.response.status}}</div>
-          </div>
-          <div class="data-group left-indent">
-            <label>Timestamp: </label>
-            <div class="data-value">{{record.response.timestamp | date:'yyyy-MM-dd HH:mm:ss Z'}}</div>
-          </div>
-          <div class="data-group left-indent" ng-if="record.response.headers">
-            <label>Headers: </label>
-            <div class="data-value showHideNoPadding">
-              <table class=" collapse" id="responseHeaders{{record._id}}">
-                <tr ng-repeat="(key, property) in record.response.headers">
-                  <td class="headerDetailsTD">{{key}}: </td>
-                  <td><strong>{{property}}</strong></td>
+          <a data-toggle="collapse" href="#popup-req-headers-table" ng-if="route.type === 'http'">Show Headers <i class="glyphicon glyphicon-chevron-down"></i></a>
+          <div id="popup-req-headers-table" class="panel panel-default collapse">
+            <div class="panel-body">
+              <table class="table-condensed table-borderless">
+                <tr ng-repeat="(key, property) in record.request.headers">
+                  <th>{{key}}: </th>
+                  <td>{{property}}</td>
                 </tr>
               </table>
-              <a class="showHideHeadersBtn" data-toggle="collapse" data-target="#responseHeaders{{record._id}}">Show/Hide Headers</a>            
             </div>
           </div>
 
-          <div ng-if="record.response.body" style="display: inline-block; width: 100%">
-            <label>Body:</label>
-            <div class="data-group">
-              <div class="data-value">
-                <div ng-if="responseTransformLang" class="hljsFormat" hljs source="record.response.body" language="{{responseTransformLang}}" style="max-height: 350px;"></div>
-                <div ng-if="!responseTransformLang" class="hljsFormatNone" style="max-height: 350px;">{{record.response.body}}</div>
-              </div>
-              <!-- show only if record has response body -->
-              <button type="button" class="btn btn-primary" ng-click="toggleFullView('Response', record.response.body, responseTransformLang)" style="float: right; margin-top: 10px;">
-                <span>View Full Response Body</span>
-              </button>
-            </div>
+          <div ng-if="record.request.body" style="display: inline-block; width: 100%; margin-top: 15px;">
+            <h4>Request body</h4>
+            <div class="hljsFormat" hljs source="record.request.body"></div>
+            <button style="margin-top: 10px;" class="btn btn-primary pull-right" ng-click="toggleFullView('Request', record.request.body, record.request.headers);">View Full Request Body</button>
           </div>
-
-          <div ng-show="record.orchestrations" style="display: inline-block; width: 100%">
-            <label>Orchestrations: </label>
-            <div id="no-more-tables" class="data-group">
-              <div class="data-value">
-              <!-- Table with all the orchestrations -->
-              <table class="table table-striped">
-                <thead>
-                  <tr>
-                    <th>Name</th>
-                    <th>Method</th>
-                    <th>Host</th>                      
-                    <th>Port</th>                      
-                    <th>Path</th>                      
-                    <th>Request Params</th>
-                    <th>Status</th>
-                    <th>Response Time</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr class="table-list" ng-repeat="orchestration in record.orchestrations" ng-click='viewAddReqResDetails(orchestration)'>
-                    <td data-title="Name">{{ orchestration.name }}</td>
-                    <td data-title="Method">{{ orchestration.request.method }}</td>
-                    <td data-title="Host">{{ orchestration.request.host }}</td>
-                    <td data-title="Port">{{ orchestration.request.port }}</td>
-                    <td data-title="Path">{{ orchestration.request.path }}</td>
-                    <td data-title="Request Params">{{ orchestration.request.querystring }}</td>
-                    <td data-title="Status">{{ orchestration.response.status }}</td>
-                    <td data-title="Response Time">{{ orchestration.response.timestamp | date:'yyyy-MM-dd HH:mm:ss Z' }}</td>
-                  </tr>
-                </tbody>
-              </table>
-            </div>
-            </div>
-          </div>
-
-          <div ng-show="record.properties" style="display: inline-block; width: 100%">
-            <label>Properties: </label>
-            <div class="data-group">
-              <div class="data-value">
-                <div class="content-box-large default-labels-box" ng-repeat="(key, property) in record.properties">
-                  {{key}}: <strong>{{property}}</strong>
-                </div>  
-              </div>
-            </div>
+          <div ng-if="route && !record.request.body" style="display: inline-block; width: 100%; margin-top: 15px;">
+            <h4>Request body not stored, it is the same as the primary route</h4>
           </div>
         </div>
       </div>
-    </tab>
-  </tabset>
+    </div>
+
+    <!-- Response, right -->
+    <div class="col-md-6" ng-if="record.response">
+      <div class="panel panel-default sml-margin transaction-req-res-height">
+        <div class="panel-heading">
+          <h3 class="panel-title">Response</h3>
+        </div>
+        <div class="panel-body">
+          <div ng-if="route">
+          <span class="label label-danger" ng-if="route.type !== 'http'">{{route.type | uppercase}}</span>
+            <h4 ng-if="route.type === 'http'">Status code
+              <span ng-if="record.response.status >= 200 && record.response.status < 300" class="label label-success">{{record.response.status}}</span>
+              <span ng-if="record.response.status >= 300 && record.response.status < 400" class="label label-primary">{{record.response.status}}</span>
+              <span ng-if="record.response.status >= 400 && record.response.status < 500" class="label label-warning">{{record.response.status}}</span>
+              <span ng-if="record.response.status >= 500 && record.response.status < 600" class="label label-danger">{{record.response.status}}</span>
+            </h4>
+          </div>
+          <!-- Assume its HTTP, can't do much else -->
+          <div ng-if="!route">
+            <h4>Status code
+              <span ng-if="record.response.status >= 200 && record.response.status < 300" class="label label-success">{{record.response.status}}</span>
+              <span ng-if="record.response.status >= 300 && record.response.status < 400" class="label label-primary">{{record.response.status}}</span>
+              <span ng-if="record.response.status >= 400 && record.response.status < 500" class="label label-warning">{{record.response.status}}</span>
+              <span ng-if="record.response.status >= 500 && record.response.status < 600" class="label label-danger">{{record.response.status}}</span>
+            </h4>
+          </div>
+          <h6 class="subtitle"><em>Received at {{record.response.timestamp | date:'yyyy-MM-dd HH:mm:ss.sss Z'}}</em></h6>
+
+          <a data-toggle="collapse" href="#popup-res-headers-table" ng-if="route.type === 'http'">Show Headers <i class="glyphicon glyphicon-chevron-down"></i></a>
+          <div id="popup-res-headers-table" class="panel panel-default collapse">
+            <div class="panel-body">
+              <table class="table-condensed table-borderless">
+                <tr ng-repeat="(key, property) in record.response.headers">
+                  <th>{{key}}: </th>
+                  <td>{{property}}</td>
+                </tr>
+              </table>
+            </div>
+          </div>
+
+          <div ng-if="record.response.body" style="display: inline-block; width: 100%; margin-top: 15px;">
+            <h4>Response body</h4>
+            <div class="hljsFormat" hljs source="record.response.body"></div>
+            <button style="margin-top: 10px;" class="btn btn-primary pull-right" ng-click="toggleFullView('Response', record.response.body, record.response.headers);">View Full Response Body</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
 
   <div class="route-detail-container" ng-show="viewFullBody">
     <div class="data-group left-indent">
       <div class="data-value" style="padding-left: 0">
-        <div ng-if="fullBodyTransformLang" class="hljsFormat hljsFormatFull" hljs source="viewFullBodyContent" language="{{fullBodyTransformLang}}"></div>
-        <div ng-if="!fullBodyTransformLang" class="hljsFormatNone hljsFormatNoneFull">{{viewFullBodyContent}}</div>
+        <div ng-if="fullBodyTransformLang" class="hljsFormat hljsFormatFull" hljs source="viewFullBodyContent"></div>
       </div>
     </div>
     <!-- show only if full body is show -->

--- a/app/views/transactionsBodyModal.html
+++ b/app/views/transactionsBodyModal.html
@@ -7,8 +7,7 @@
   <div class="route-detail-container">
     <div class="data-group left-indent">
       <div class="data-value" style="padding-left: 0">
-        <div ng-if="bodyTransformLang" class="hljsFormat hljsFormatFull" hljs source="bodyData.content" language="{{bodyTransformLang}}"></div>
-        <div ng-if="!bodyTransformLang" class="hljsFormatNone hljsFormatNoneFull">{{bodyData.content}}</div>
+        <div class="hljsFormat hljsFormatFull" hljs source="bodyData.content"></div>
       </div>
     </div>
   </div>

--- a/test/spec/controllers/transactionsAddReqResModal.js
+++ b/test/spec/controllers/transactionsAddReqResModal.js
@@ -37,7 +37,7 @@ describe('Controller: TransactionsAddReqResModalCtrl', function () {
 
       scope = $rootScope.$new();
       modalInstance = sinon.spy();
-      return $controller('TransactionsAddReqResModalCtrl', { $scope: scope, $modalInstance: modalInstance, record: record } );
+      return $controller('TransactionsAddReqResModalCtrl', { $scope: scope, $modalInstance: modalInstance, record: record, route: null } );
     };
 
   }));


### PR DESCRIPTION
Closes #336 also closes #303 and closes #304 

I have decided to go with a solution that uses sessionStorage to stores an array of `_id`s for the current filtered transactions. The reason for this was two fold:

* It allows the transaction query to only happen once, not on every transaction details page load.
* It allowed me to not have to reimplement support for all of the filters that we currently have. The code there is not easily reused. I think that code need to be refactored a bit and I didn't want to proliferate it. (https://github.com/jembi/openhim-core-js/issues/589)

It seem to work pretty well so far, but I'm interested to know what other think.

@devcritter could you review this for me and @BMartinos could you have a look at some of the UI changes and let me know if there is anything I should do differently or if you have any better design ideas.

I also, cleaned up some of the css which was overriding some default bootstrap stuff (that isn't ideal). This may have some styling impact on other pages. I've had a look and tried to resolve these, but if you notice any others please let me know.

Also, @armageddon does this solve your problem for momconnect?

See some quick pics below:

![image](https://cloud.githubusercontent.com/assets/266576/11117830/ab51ebfc-8945-11e5-9e2f-f041028969f5.png)

![image](https://cloud.githubusercontent.com/assets/266576/11117679/7fe14734-8944-11e5-9744-2ec08d6522c7.png)

![image](https://cloud.githubusercontent.com/assets/266576/11117845/cb8b0868-8945-11e5-8cda-27a2ed0b6c61.png)