### PR TITLE
Issue #357: Informative error message on connection failure

### DIFF
--- a/app/scripts/controllers/login.js
+++ b/app/scripts/controllers/login.js
@@ -2,7 +2,9 @@
 /* global getHashAndSalt: false */
 
 angular.module('openhimConsoleApp')
-  .controller('LoginCtrl', function ($scope, login, $window, $timeout, $rootScope, Alerting, Api) {
+  .controller('LoginCtrl', function ($scope, login, $window, $timeout, $rootScope, Alerting, Api, config) {
+
+    $scope.heartbeatLink = 'https://' + config.host + ':' + config.port + '/heartbeat';
 
     $scope.rootPasswordReset = false;
     $scope.resetSuccess = false;
@@ -28,6 +30,7 @@ angular.module('openhimConsoleApp')
         // reset alert to show processing message
         Alerting.AlertReset();
         Alerting.AlertAddMsg('login', 'warning', 'Busy checking your credentials...');
+        $scope.coreConnectionError = false;
 
         //check login credentials and create session if valid
         $scope.checkLoginCredentials(loginEmail, loginPassword);
@@ -60,7 +63,7 @@ angular.module('openhimConsoleApp')
 
         }else{
           if ( result === 'Internal Server Error' ){
-            Alerting.AlertAddServerMsg();
+            $scope.coreConnectionError = true;
           }else{
             Alerting.AlertAddMsg('login', 'danger', 'The supplied credentials were incorrect. Please try again');
           }

--- a/app/scripts/controllers/login.js
+++ b/app/scripts/controllers/login.js
@@ -4,7 +4,7 @@
 angular.module('openhimConsoleApp')
   .controller('LoginCtrl', function ($scope, login, $window, $timeout, $rootScope, Alerting, Api, config) {
 
-    $scope.heartbeatLink = 'https://' + config.host + ':' + config.port + '/heartbeat';
+    $scope.config = config;
 
     $scope.rootPasswordReset = false;
     $scope.resetSuccess = false;

--- a/app/views/login.html
+++ b/app/views/login.html
@@ -46,9 +46,9 @@
       </div>
 
       <div ng-if="coreConnectionError" class="alert alert-danger" style="padding: 10px; margin: 15px 10%;">
-          An error occurred while attempting to connect to the OpenHIM Core.<br><br>
+          An error occurred while attempting to connect to the OpenHIM Core on https://{{config.host}}:{{config.port}}.<br><br>
           The service may not be running or may not be accessible from you current location.<br><br>
-          Additionally if Core is using a self-signed certificate, you may first need to instruct your browser to accept it. You can do so by accessing the following <a target="_blank" href="{{heartbeatLink}}">link</a>.<br><br>
+          Additionally if Core is using a self-signed certificate, you may first need to instruct your browser to accept it. You can do so by accessing the following <a target="_blank" href="https://{{config.host}}:{{config.port}}/heartbeat">link</a>.<br><br>
           Please contact your system administrator if the error persists or if the service was not accessible using the above link.
       </div>
 

--- a/app/views/login.html
+++ b/app/views/login.html
@@ -45,6 +45,13 @@
         </div>
       </div>
 
+      <div ng-if="coreConnectionError" class="alert alert-danger" style="padding: 10px; margin: 15px 10%;">
+          An error occurred while attempting to connect to the OpenHIM Core.<br><br>
+          The service may not be running or may not be accessible from you current location.<br><br>
+          Additionally if Core is using a self-signed certificate, you may first need to instruct your browser to accept it. You can do so by accessing the following <a target="_blank" href="{{heartbeatLink}}">link</a>.<br><br>
+          Please contact your system administrator if the error persists or if the service was not accessible using the above link.
+      </div>
+
       <div ng-if="loginBanner" class="box" ng-bind-html="loginBanner" style="padding: 10px; margin: 15px 10%;"></div>
 
     </div>


### PR DESCRIPTION
Closes #357 

@rcrichton @BMartinos I thought it'd be great to get this in before the next release.

Unfortunately I can't see a good way to specifically determine that it's a cert issue (and seems to be a general [problem](http://stackoverflow.com/questions/31058764/determine-if-ajax-call-failed-due-to-insecure-response-or-connection-refused)) so just wrote it up generically