### PR TITLE
OHM-387 Fix response time labels

### DIFF
--- a/app/scripts/controllers/channelMonitoring.js
+++ b/app/scripts/controllers/channelMonitoring.js
@@ -36,8 +36,8 @@ angular.module('openhimConsoleApp')
         var round = function (d) {
           return (d).toFixed(2);
         };
-        $scope.transactionLoadData = Metrics.buildLineChartData($scope.selectedDateType, metrics, 'total');
-        $scope.transactionResponseTimeData = Metrics.buildLineChartData($scope.selectedDateType, metrics, 'avgResp', round);
+        $scope.transactionLoadData = Metrics.buildLineChartData($scope.selectedDateType, metrics, 'total', 'Transactions');
+        $scope.transactionResponseTimeData = Metrics.buildLineChartData($scope.selectedDateType, metrics, 'avgResp', 'Response Time (ms)', round);
       }
     }
 

--- a/app/scripts/controllers/dashboard.js
+++ b/app/scripts/controllers/dashboard.js
@@ -25,8 +25,8 @@ angular.module('openhimConsoleApp')
         var round = function (d) {
           return (d).toFixed(2);
         };
-        $scope.transactionLoadData = Metrics.buildLineChartData($scope.selectedDateType, metrics, 'total');
-        $scope.transactionResponseTimeData = Metrics.buildLineChartData($scope.selectedDateType, metrics, 'avgResp', round);
+        $scope.transactionLoadData = Metrics.buildLineChartData($scope.selectedDateType, metrics, 'total', 'Transactions');
+        $scope.transactionResponseTimeData = Metrics.buildLineChartData($scope.selectedDateType, metrics, 'avgResp', 'Response Time (ms)', round);
       }
     }
 

--- a/app/scripts/services/metrics.js
+++ b/app/scripts/services/metrics.js
@@ -33,7 +33,7 @@ angular.module('openhimConsoleApp')
         }
       },
 
-      buildLineChartData: function(selectedPeriod, metrics, key, valueFormatter) {
+      buildLineChartData: function(selectedPeriod, metrics, key, label, valueFormatter) {
         var graphData = [];
         var from = moment(selectedPeriod.from);
         var until = moment(selectedPeriod.until);
@@ -69,7 +69,7 @@ angular.module('openhimConsoleApp')
           data: graphData,
           xkey: 'timestamp',
           ykeys: ['value'],
-          labels: ['Transactions'],
+          labels: [label],
           loadTotal: loadTotal,
           avgResponseTime: avgResponseTime
         };

--- a/test/spec/controllers/channelMonitoring.js
+++ b/test/spec/controllers/channelMonitoring.js
@@ -156,7 +156,7 @@ describe('Controller: ChannelMonitoringCtrl', function () {
     scope.transactionResponseTimeData.should.have.property('ykeys');
     scope.transactionResponseTimeData.ykeys[0].should.equal('value');
     scope.transactionResponseTimeData.should.have.property('labels');
-    scope.transactionResponseTimeData.labels[0].should.equal('Transactions');
+    scope.transactionResponseTimeData.labels[0].should.equal('Response Time (ms)');
 
     scope.transactionResponseTimeData.data[0].should.have.property('timestamp');
     scope.transactionResponseTimeData.data[0].should.have.property('value', '2881.91');

--- a/test/spec/controllers/dashboard.js
+++ b/test/spec/controllers/dashboard.js
@@ -115,7 +115,7 @@ describe('Controller: DashboardCtrl', function () {
     scope.transactionResponseTimeData.ykeys[0].should.equal('value');
     scope.transactionResponseTimeData.should.have.property('labels');
     scope.transactionResponseTimeData.labels.length.should.equal(1);
-    scope.transactionResponseTimeData.labels[0].should.equal('Transactions');
+    scope.transactionResponseTimeData.labels[0].should.equal('Response Time (ms)');
 
     scope.transactionResponseTimeData.data.length.should.equal(5);
 
@@ -181,7 +181,7 @@ describe('Controller: DashboardCtrl', function () {
     scope.transactionResponseTimeData.ykeys[0].should.equal('value');
     scope.transactionResponseTimeData.should.have.property('labels');
     scope.transactionResponseTimeData.labels.length.should.equal(1);
-    scope.transactionResponseTimeData.labels[0].should.equal('Transactions');
+    scope.transactionResponseTimeData.labels[0].should.equal('Response Time (ms)');
 
     scope.transactionResponseTimeData.data.length.should.equal(5); // 5 days of data
 


### PR DESCRIPTION
Update the graphs on the dashboard and channel metrics pages to show the
label for the response time as "Reponse Time" instead of "Transactions".