### PR TITLE
OHM-407 Fix taglist to work properly when clicking on an autocomplete option

### DIFF
--- a/app/views/partials/channels-tab-request-matching.html
+++ b/app/views/partials/channels-tab-request-matching.html
@@ -4,7 +4,7 @@
 
 <div class="form-group-2columns">
   <div class="form-group" style="float: left; width: 75%" ng-class="{ 'has-error' : ngError.urlPattern }" ng-if="channel.type === 'http' || channel.type === 'polling'">
-    
+
     <div class="form-group" style="float: left; width: 75%">
       <label><span>*</span> Which URL patterns will match this channel?</label>
       <div class="input-group" style="width: 100%;">
@@ -46,7 +46,7 @@
 
 <div class="form-group" ng-if="channel.authType == 'private'" ng-class="{ 'has-error' : ngError.allow }">
   <label><span>*</span> Which clients should be able to access this channel?</label>
-  <taglist tag-data="channel.allow" ><input class="form-control" placeholder="Enter a specifc client or role and press enter..." type="text" ng-model="allowedRoles" typeahead="role for role in taglistClientRoleOptions | filter:$viewValue" /></taglist>
+  <taglist tag-data="channel.allow" taglist-blur-timeout="200"><input class="form-control" placeholder="Enter a specifc client or role and press enter..." type="text" ng-model="allowedRoles" typeahead="role for role in taglistClientRoleOptions | filter:$viewValue" /></taglist>
   <div class="has-error-msg"><i class="glyphicon glyphicon-warning-sign"></i>{{validationRequiredMsg}}</div>
 </div>
 
@@ -65,7 +65,7 @@
     <label>Are there any particular Content-Types that you wish to match on?</label>
     <taglist tag-data="channel.matchContentTypes"><input class="form-control" placeholder="Enter a content type and press enter..." type="text" /></taglist>
   </div>
-  
+
   <div class="form-group">
     <label>Do you want to match on request BODY content? </label>
     <div style="display: block;">

--- a/app/views/partials/channels-tab-user-access.html
+++ b/app/views/partials/channels-tab-user-access.html
@@ -7,19 +7,19 @@
   	Which user groups are allowed to view this channel's transactions?
   	<i ng-show="uiSettings.showTooltips" tooltip="Supply the groups allowed to view this Channel’s transactions" class="glyphicon glyphicon-question-sign tooltip-wide"></i>
   </label>
-  <taglist tag-data="channel.txViewAcl"><input class="form-control" placeholder="Enter specific user groups..." type="text" ng-model="txViewAcl" typeahead="group for group in taglistUserRoleOptions | filter:$viewValue" /></taglist>
+  <taglist tag-data="channel.txViewAcl" taglist-blur-timeout="200"><input class="form-control" placeholder="Enter specific user groups..." type="text" ng-model="txViewAcl" typeahead="group for group in taglistUserRoleOptions | filter:$viewValue" /></taglist>
 </div>
 <div class="form-group">
   <label>
   	Which user groups are allowed to view this channel's transactions full request/response body?
   	<i ng-show="uiSettings.showTooltips" tooltip="Supply the groups allowed to view the request/response body of this Channel’s transactions" class="glyphicon glyphicon-question-sign tooltip-wide"></i>
   </label>
-  <taglist tag-data="channel.txViewFullAcl"><input class="form-control" placeholder="Enter specific user groups..." type="text" ng-model="txViewFullAcl" typeahead="group for group in taglistUserRoleOptions | filter:$viewValue" /></taglist>
+  <taglist tag-data="channel.txViewFullAcl" taglist-blur-timeout="200"><input class="form-control" placeholder="Enter specific user groups..." type="text" ng-model="txViewFullAcl" typeahead="group for group in taglistUserRoleOptions | filter:$viewValue" /></taglist>
 </div>
 <div class="form-group">
   <label>
   	Which user groups are allowed to rerun this channel's transactions?
   	<i ng-show="uiSettings.showTooltips" tooltip="Supply the groups allowed to rerun this Channel’s transactions" class="glyphicon glyphicon-question-sign tooltip-wide"></i>
  	</label>
-  <taglist tag-data="channel.txRerunAcl"><input class="form-control" placeholder="Enter specific user groups..." type="text" ng-model="txRerunAcl" typeahead="group for group in taglistUserRoleOptions | filter:$viewValue" /></taglist>
+  <taglist tag-data="channel.txRerunAcl" taglist-blur-timeout="200"><input class="form-control" placeholder="Enter specific user groups..." type="text" ng-model="txRerunAcl" typeahead="group for group in taglistUserRoleOptions | filter:$viewValue" /></taglist>
 </div>

--- a/app/views/profile.html
+++ b/app/views/profile.html
@@ -44,7 +44,7 @@
                   <div class="has-error-msg"><i class="glyphicon glyphicon-warning-sign"></i>{{validationRequiredMsg}}</div>
                 </div>
               </div>
-              
+
               <div class="form-group" ng-class="{ 'has-error' : ngError.msisdn }">
                 <label>
                   Phone number (MSISDN format)
@@ -57,7 +57,7 @@
               <!-- if user is admin -->
               <div ng-show="userGroupAdmin" class="form-group" ng-class="{ 'has-error' : ngError.groups }">
                 <label><span>*</span> Groups</label>
-                <taglist tag-data="user.groups"><input class="form-control" placeholder="Enter a group and press enter..." type="text" ng-model="roles" typeahead="group for group in taglistUserRoleOptions | filter:$viewValue" /></taglist>
+                <taglist tag-data="user.groups" taglist-blur-timeout="200"><input class="form-control" placeholder="Enter a group and press enter..." type="text" ng-model="roles" typeahead="group for group in taglistUserRoleOptions | filter:$viewValue" /></taglist>
                 <div class="has-error-msg"><i class="glyphicon glyphicon-warning-sign"></i>{{validationRequiredMsg}}</div>
               </div>
 
@@ -97,7 +97,7 @@
                 </div>
               </div>
 
-              
+
               <!-- include for user settings tabs -->
               <div ng-include="'views/partials/user-settings-tabs.html'" style="margin-bottom: 20px;"></div>
 
@@ -107,7 +107,7 @@
             <!-- Server Alerts -->
             <alert ng-repeat="alert in alerts.server" type="alert.type">{{alert.msg}}</alert>
             <!-- Server Alerts -->
-            
+
             <button type="button" class="btn btn-primary" style="float: left;" ng-click="submitFormProfile()">Save changes</button>
 
             <!-- hasErrors Alerts -->
@@ -115,15 +115,15 @@
               <i class="glyphicon glyphicon-warning-sign"></i>{{alert.msg}}
             </alert>
             <!-- hasErrors Alerts -->
-            
-          </form>  
+
+          </form>
 
           <!-- show loading gif when scope object empty and no server errors exist -->
           <div class="loadingContainer" ng-show="!(user || alerts.server)">
             <img src="images/loading.gif" alt="Loading..." />
           </div>
-          
-        </div>        
+
+        </div>
       </div>
     </div>
   </div>

--- a/app/views/usersmodal.html
+++ b/app/views/usersmodal.html
@@ -46,7 +46,7 @@
 
       <div class="form-group" ng-class="{ 'has-error' : ngError.groups }">
         <label><span>*</span> Permission Groups</label>
-        <taglist tag-data="user.groups"><input class="form-control" placeholder="Enter a group and press enter..." type="text" ng-model="roles" typeahead="group for group in taglistUserRoleOptions | filter:$viewValue" /></taglist>
+        <taglist tag-data="user.groups" taglist-blur-timeout="200"><input class="form-control" placeholder="Enter a group and press enter..." type="text" ng-model="roles" typeahead="group for group in taglistUserRoleOptions | filter:$viewValue" /></taglist>
         <div class="has-error-msg"><i class="glyphicon glyphicon-warning-sign"></i>{{validationRequiredMsg}}</div>
       </div>
 


### PR DESCRIPTION
The taglist was setting a tag as soon as an option was clicked but
before the model was updated with the full value of the autocompleted
tag. So, we would end up with the partial text as the tag and the
autocompleted text in the input box. The taglist directive was updated
with an on-blur timeout for this very reason, the fix was to use it when
doing autocomplete.