### PR TITLE
Reverse transactions before adding them to the log

### DIFF
--- a/app/scripts/controllers/transactions.js
+++ b/app/scripts/controllers/transactions.js
@@ -956,7 +956,7 @@ angular.module('openhimConsoleApp')
 
         Api.Transactions.query(filters, function(transactions) {
           lastPollingCompleted = true;
-          transactions.forEach(function(trx) {
+          transactions.reverse().forEach(function(trx) {
             $scope.transactions.unshift(trx);
             $scope.baseIndex--;
           });

--- a/test/spec/controllers/transactions.js
+++ b/test/spec/controllers/transactions.js
@@ -247,6 +247,14 @@ describe('Controller: TransactionsCtrl', function() {
 
     httpBackend.when('GET', new RegExp('.*/transactions')).respond([
       {
+        '_id' : '59a010234c3c346c24d01f6e',
+        'status' : 'Successful',
+        'clientID' : '5506aed5348ac60d23840a9e',
+        'channelID' : '550933dbbc9814c82b12fd16',
+        'request' : { 'path' : '/path/successful', 'headers' : { }, 'querystring' : 'test=testing', 'body' : 'Successful', 'method' : 'GET', 'timestamp' : '2017-08-25T11:55:38.953Z' },
+        'response' : { 'timestamp' : '2017-08-25T11:56:38.953Z', 'body' : 'Body', 'headers' : {  }, 'status' : 200 }
+      },
+      {
         '_id' : '550936d307756ef72b525555',
         'status' : 'Successful',
         'clientID' : '5506aed5348ac60d23840a9e',
@@ -259,8 +267,9 @@ describe('Controller: TransactionsCtrl', function() {
     scope.pollForLatest();
     httpBackend.flush();
 
-    scope.transactions.length.should.equal(originalLength + 1);
-    scope.transactions[0]._id.should.equal('550936d307756ef72b525555');
+    scope.transactions.length.should.equal(originalLength + 2);
+    scope.transactions[0]._id.should.equal('59a010234c3c346c24d01f6e');
+    scope.transactions[1]._id.should.equal('550936d307756ef72b525555');
   });
 
   it('should update "Processing" transactions', function() {


### PR DESCRIPTION
The new transactions which are returned when polling for updates are
received in reverse chronological order from the core. Iterating through
them to add them to the current list of transactions reverses this
order. Since the API does not support a parameter to change the sort
order the new transactions need to be reversed before they are added to
the log.

OHM-460