### PR TITLE
Show an icon for rerun transactions on list and details pages

### DIFF
--- a/app/styles/main.css
+++ b/app/styles/main.css
@@ -647,7 +647,7 @@ body {
 
 .transactionsCheckboxTD{
   padding: 0px !important;
-  width: 50px;
+  width: 70px;
 }
 
 .transactionsCheckboxTD .glyphicon{

--- a/app/views/transactionDetails.html
+++ b/app/views/transactionDetails.html
@@ -13,6 +13,7 @@
             <h2>
               <i ng-if="transactionDetails.childIDs.length == 0" class="glyphicon glyphicon-tasks"></i>
               <i ng-if="transactionDetails.childIDs.length > 0" class="glyphicon glyphicon-repeat"></i>
+              <i ng-if="transactionDetails.parentID" class="glyphicon glyphicon-retweet"></i>
               &nbsp;Transaction details</h2>
           </div>
         </div>

--- a/app/views/transactionDetails.html
+++ b/app/views/transactionDetails.html
@@ -6,14 +6,13 @@
     <div class="col-md-10">
 
       <div class="content-box-large">
-
         <!-- Heading -->
         <div class="panel-heading">
           <div class="panel-title">
             <h2>
               <i ng-if="transactionDetails.childIDs.length == 0" class="glyphicon glyphicon-tasks"></i>
-              <i ng-if="transactionDetails.childIDs.length > 0" class="glyphicon glyphicon-repeat"></i>
-              <i ng-if="transactionDetails.parentID" class="glyphicon glyphicon-retweet"></i>
+              <i ng-if="transactionDetails.childIDs.length > 0" class="glyphicon glyphicon-repeat" title="Has been rerun"></i>
+              <i ng-if="transactionDetails.parentID" class="glyphicon glyphicon-refresh" title="Is a rerun transaction"></i>
               &nbsp;Transaction details</h2>
           </div>
         </div>

--- a/app/views/transactions.html
+++ b/app/views/transactions.html
@@ -97,8 +97,9 @@
                 <tr class="table-list" ng-repeat="transaction in transactions" ng-class="{transactionsNew: baseIndex + $index < 0}" ng-click='viewTransactionDetails("transactions/" + transaction._id, $event)'>
                   <td class="transactionsCheckboxTD">
                     <label>
-                      <input style="float: left" type="checkbox" ng-change="toggleTransactionSelection(transaction._id)" ng-if="channelsMap[transaction.channelID].rerun && transaction.canRerun" ng-checked="checkbox.checkAll" ng-model="checkBox" value="transaction._id"/>
+                      <input type="checkbox" ng-change="toggleTransactionSelection(transaction._id)" ng-if="channelsMap[transaction.channelID].rerun && transaction.canRerun" ng-checked="checkbox.checkAll" ng-model="checkBox" value="transaction._id"/>
                       <i ng-if="transaction.childIDs.length > 0" class="glyphicon glyphicon-repeat"></i>
+                      <i ng-if="transaction.parentID" class="glyphicon glyphicon-retweet"></i>
                     </label>
                   </td>
                   <td data-title="# {{ baseIndex + $index +1 }}" class="responsiveTransactionIndexCheckbox">

--- a/app/views/transactions.html
+++ b/app/views/transactions.html
@@ -98,8 +98,8 @@
                   <td class="transactionsCheckboxTD">
                     <label>
                       <input type="checkbox" ng-change="toggleTransactionSelection(transaction._id)" ng-if="channelsMap[transaction.channelID].rerun && transaction.canRerun" ng-checked="checkbox.checkAll" ng-model="checkBox" value="transaction._id"/>
-                      <i ng-if="transaction.childIDs.length > 0" class="glyphicon glyphicon-repeat"></i>
-                      <i ng-if="transaction.parentID" class="glyphicon glyphicon-retweet"></i>
+                      <i ng-if="transaction.childIDs.length > 0" class="glyphicon glyphicon-repeat" title="Has been rerun"></i>
+                      <i ng-if="transaction.parentID" class="glyphicon glyphicon-refresh" title="Is a rerun transaction"></i>
                     </label>
                   </td>
                   <td data-title="# {{ baseIndex + $index +1 }}" class="responsiveTransactionIndexCheckbox">


### PR DESCRIPTION
Prior to this change, there was no way to show the user that a
transaction is the result of a rerun transaction request.

This change will show an icon (glyphicon-retweet) for transactions
that are reruns in the 'transactions log' page. It will also show
an icon for these transactions on the 'transaction details' page.
Where the transaction is a reun and the parent of a rerun, both
indicators will be displayed.

OHM-662