### PR TITLE
OHM-834 User groups order dictate if transaction can be rerun

### DIFF
--- a/app/scripts/controllers/transactions.js
+++ b/app/scripts/controllers/transactions.js
@@ -208,13 +208,12 @@ export function TransactionsCtrl ($scope, $uibModal, $location, $timeout, $inter
         if (userGroups.indexOf('admin') >= 0) {
           $scope.channelsMap[channel._id].rerun = true
         } else {
-          angular.forEach(userGroups, function (role) {
-            if (channel.txRerunAcl.indexOf(role) >= 0) {
+          for (let i = 0; i < userGroups.length; ++i) {
+            if (channel.txRerunAcl.indexOf(userGroups[i]) >= 0) {
               $scope.channelsMap[channel._id].rerun = true
-            } else {
-              $scope.channelsMap[channel._id].rerun = false
+              break
             }
-          })
+          }
         }
       } else {
         $scope.channelsMap[channel._id].rerun = false

--- a/app/scripts/controllers/transactions.js
+++ b/app/scripts/controllers/transactions.js
@@ -208,17 +208,8 @@ export function TransactionsCtrl ($scope, $uibModal, $location, $timeout, $inter
         if (userGroups.indexOf('admin') >= 0) {
           $scope.channelsMap[channel._id].rerun = true
         } else {
-          let i
-          for (i = 0; i < userGroups.length; ++i) {
-            if (channel.txRerunAcl.indexOf(userGroups[i]) >= 0) {
-              $scope.channelsMap[channel._id].rerun = true
-              break
-            }
-          }
-
-          if (i === userGroups.length) {
-            $scope.channelsMap[channel._id].rerun = false
-          }
+          const groupsAllowedToRerun = userGroups.filter(group => channel.txRerunAcl.includes(group))
+          $scope.channelsMap[channel._id].rerun = groupsAllowedToRerun.length > 0
         }
       } else {
         $scope.channelsMap[channel._id].rerun = false

--- a/app/scripts/controllers/transactions.js
+++ b/app/scripts/controllers/transactions.js
@@ -208,11 +208,16 @@ export function TransactionsCtrl ($scope, $uibModal, $location, $timeout, $inter
         if (userGroups.indexOf('admin') >= 0) {
           $scope.channelsMap[channel._id].rerun = true
         } else {
-          for (let i = 0; i < userGroups.length; ++i) {
+          let i
+          for (i = 0; i < userGroups.length; ++i) {
             if (channel.txRerunAcl.indexOf(userGroups[i]) >= 0) {
               $scope.channelsMap[channel._id].rerun = true
               break
             }
+          }
+
+          if (i === userGroups.length) {
+            $scope.channelsMap[channel._id].rerun = false
           }
         }
       } else {

--- a/test/spec/controllers/transactions.js
+++ b/test/spec/controllers/transactions.js
@@ -313,4 +313,36 @@ describe('Controller: TransactionsCtrl', function () {
     scope.transactions[2]._id.should.equal('770936d307756ef72b525333')
     scope.transactions[2].status.should.equal('Failed')
   })
+
+  it('should check rerun permissions (non admin user should have permission on enabled channel)', function () {
+    // Change the userGroups from admin. The userGroups are stored in a session upon login. 
+    // They are used to determine if a user can rerun a channel's transactions
+    var session = localStorage.getItem('consoleSession')
+    localStorage.removeItem('consoleSession')
+    session = JSON.parse(session)
+    session.sessionUserGroups = ['test1', 'test', 'test2', 'test2']
+    localStorage.setItem('consoleSession', JSON.stringify(session))
+
+    createController()
+    httpBackend.flush()
+    
+    scope.channelsMap['5322fe9d8b6add4b2b059dd8'].should.have.property('rerun', true)
+    scope.channelsMap['5322fe9d8b6add4b2b059aa3'].should.have.property('rerun', false)
+  })
+
+  it('should check rerun permissions (non admin user should not have permission on enabled channel)', function () {
+    // Change the userGroups from admin. The userGroups are stored in a session upon login. 
+    // They are used to determine if a user can rerun a channel's transactions
+    var session = localStorage.getItem('consoleSession')
+    localStorage.removeItem('consoleSession')
+    session = JSON.parse(session)
+    session.sessionUserGroups = ['test1', 'test2', 'test3', 'test4']
+    localStorage.setItem('consoleSession',JSON.stringify(session))
+
+    createController()
+    httpBackend.flush()
+
+    scope.channelsMap['5322fe9d8b6add4b2b059dd8'].should.have.property('rerun', false)
+    scope.channelsMap['5322fe9d8b6add4b2b059aa3'].should.have.property('rerun', false)
+  })
 })


### PR DESCRIPTION
The app currently processes the user's permissions based on the order of
the user groups from the API. What this means is that if a user belongs to
two or more user groups and the required group is not last in the list,
the user would have no permission to re-run transactions.

This is a UI logic related issue where the required checkbox for re-running
a transaction is not being displayed when it needs to be.

I have added a fix to correctly process the permissions related to
a channel and the logged in user.

Related Tickets:
 - OHM-834