### PR TITLE
OHIE-280 Document OpenHIM Core API protocol configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Your file should look something like this:
 
 ``` json
 {
-  "protocol": "https",
+  "protocol": "https", // Change the protocol to 'http' when the OpenHIM core API protocol is 'http'. The default OpenHIM core API protocol is 'https'
   "host": "localhost", // change this to the hostname for your OpenHIM-core server (This hostname _MUST_ be publicly accessible)
   "port": 8080, // change this to the API port of the OpenHIM-core server, default is 8080
   "title": "OpenHIM Admin Console", // You may change this to customize the title of the OpenHIM-console instance


### PR DESCRIPTION
This pull request is intended to add missing documentation for the "protocol" option in the console config file. This work is done as part of new configuration options added to the OpenHIM core for the API endpoints.

Related Tickets:
 - [OHIE-280](https://jembiprojects.jira.com/secure/RapidBoard.jspa?rapidView=120&modal=detail&selectedIssue=OHIE-280)