### PR TITLE
Add npm prepare step to Docker image build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,10 @@ node_modules
 infrastructure
 packaging
 test
+Dockerfile
+.dockerignore
+.travis
+.travis.yml
+.editorconfig
+.gitignore
+.gitattributes

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,8 @@ COPY . .
 
 RUN npm install
 
+RUN npm run prepare
+
 # Serve built project with nginx
 FROM nginx:mainline-alpine
 


### PR DESCRIPTION
Running `npm i` in the docker environment does not trigger `npm prepare`
unlike local dev.
This needs to be scripted manually here

OHM-1052