### PR TITLE
docs: update README to add missing configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,14 @@ Your file should look something like this:
   "title": "OpenHIM Admin Console", // You may change this to customize the title of the OpenHIM-console instance
   "footerTitle": "OpenHIM Administration Console", // You may change this to customize the footer of the OpenHIM-console instance
   "footerPoweredBy": "<a href='http://openhim.org/' target='_blank'>Powered by OpenHIM</a>",
-  "loginBanner": "" // add text here that you want to appear on the login screen, if any.
+  "loginBanner": "", // add text here that you want to appear on the login screen, if any.
+  "showLoginForm": true, // this could be disabled in favor of a SSO using keycloak
+  "mediatorLastHeartbeatWarningSeconds": 60, // Mediator heartbeat check intervals to issue a warning status
+  "mediatorLastHeartbeatDangerSeconds": 120, // Mediator heartbeat check intervals to issue a danger status
+  "ssoEnabled": false, // enable SSO with Keycloak
+  "keyCloakUrl": "http://localhost:9088", // Keycloak URL
+  "keyCloakRealm": "platform-realm", // Keycloak Realm name
+  "keyCloakClientId": "openhim-oauth" // Keycloak client ID
 }
 ```
 


### PR DESCRIPTION
# Motivation

When the config file is missing the attribute "showLoginForm", openhim will not show the auth form (could happen when migrating from an older version). We need to add it to the documentation, not sure how to update the website. 

![image](https://user-images.githubusercontent.com/1827776/232760485-ebde677f-0798-4803-b44b-77c66301faed.png)
 
Might be good to plan a ticket to set default config that gets overriden by the user's config. @michaelloosen WDYT ?