### PR TITLE
PLAT 704 - Log user out of keycloak when logging out

### DIFF
--- a/app/scripts/controllers/login.js
+++ b/app/scripts/controllers/login.js
@@ -211,11 +211,9 @@ export function LoginCtrl ($scope, login, $window, $location, $timeout, $rootSco
   }
 
   $scope.signInWithKeyCloak = function () {
-    keycloak.keycloakInstance.init({
-      onLoad: 'login-required',
+    keycloak.keycloakInstance.login({
       // Must match to the configured value in keycloak
       redirectUri: $window.location.origin,
-      checkLoginIframe: false
     })
   }
 }

--- a/app/scripts/services/keycloak.js
+++ b/app/scripts/services/keycloak.js
@@ -13,6 +13,7 @@ export function keycloak (config) {
         realm: config.keyCloakRealm,
         clientId: config.keyCloakClientId
       })
+      keycloakInstance.init({ checkLoginIframe: false })
     }
   }
   return {

--- a/app/scripts/services/login.js
+++ b/app/scripts/services/login.js
@@ -46,14 +46,17 @@ export function login (Api, $rootScope, keycloak) {
         function () {
           // Cleanup of keycloak session
           const keycloakState = keycloak.getKeycloakState()
-          if ($rootScope.sessionUser && $rootScope.sessionProvider === 'openid' && keycloakState) {
-            localStorage.removeItem(`kc-callback-${keycloakState}`)
-          }
-
+          const isKeycloakLogin = $rootScope.sessionUser && $rootScope.sessionProvider === 'openid' && keycloakState
           userProfile = null
           $rootScope.sessionUser = null
           $rootScope.navMenuVisible = false
           localStorage.removeItem('consoleSession')
+
+          if (isKeycloakLogin) {
+            localStorage.removeItem(`kc-callback-${keycloakState}`)
+            keycloak.keycloakInstance.logout({ redirectUri: window.location.origin })
+          }
+
           done('Logout Successful')
         }, function () {
           done('Internal Server Error')

--- a/test/spec/controllers/login.js
+++ b/test/spec/controllers/login.js
@@ -27,7 +27,11 @@ describe('Controller: LoginCtrl', function () {
     keycloak = _keycloak_
 
     // Override function to prevent page reload
-    keycloak.keycloakInstance.init = () => {}
+    keycloak.keycloakInstance = {
+      init: () => {},
+      login: () => {},
+      logout: () => {}
+    }
 
     httpBackend = $httpBackend
 


### PR DESCRIPTION
In order to support single logout across all keycloak apps, openhim should call the logout method on the keycloak adapter after the normal logout flow is finished. This will redirect the user to the keycloak logout page which will then log out the user across the other logged-in apps.
Story: https://jembiprojects.jira.com/browse/PLAT-704