### PR TITLE
TB-173 show transaction error with no response

### DIFF
--- a/app/views/transactionDetails.html
+++ b/app/views/transactionDetails.html
@@ -152,7 +152,7 @@
             </div>
 
             <!-- Response, right -->
-            <div class="col-md-6" ng-if="transactionDetails.response">
+            <div class="col-md-6" ng-if="transactionDetails.response || transactionDetails.error">
               <div class="panel panel-default sml-margin transaction-req-res-height">
                 <div class="panel-heading">
                   <h3 class="panel-title">Response</h3>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "openhim-console",
 	"description": "This application provides a web application to configure and manage the OpenHIM-core component.",
-	"version": "1.18.2",
+	"version": "1.18.3",
 	"dependencies": {
 		"http-server": "^14.1.1",
 		"keycloak-js": "^20.0.3",


### PR DESCRIPTION
With the changes to Openhim in 8.1.2 it is possible for a transaction to be in a failed state but without receiving a response back from the down stream service (i.e.: Openhim crashes midflight) but it would still be nice to be able to see the error message on the now failed transaction