### PR TITLE
use Harbor registry and update Docker/CI config

### DIFF
--- a/.github/workflows/docker-image-scan.yml
+++ b/.github/workflows/docker-image-scan.yml
@@ -13,12 +13,12 @@ jobs:
 
       - name: Build an image from Dockerfile
         run: |
-          docker build -t jembi/openhim-console:${{ github.sha }} .
+          docker build -t harbor.jembidev.org/platform/openhim-console:${{ github.sha }} .
 
       - name: Run trivy vulnerability scanner for the OpenHIM console image
         uses: aquasecurity/trivy-action@master
         with:
-          image-ref: jembi/openhim-console:${{ github.sha }}
+          image-ref: harbor.jembidev.org/platform/openhim-console:${{ github.sha }}
           format: 'sarif'
           output: 'trivy-results.sarif'
         

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - harbor_config
 
   workflow_dispatch:
 

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - harbor_config
 
   workflow_dispatch:
 
@@ -21,11 +22,12 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
+      - name: Login to Harbor
+        uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+          registry: harbor.jembidev.org
+          username: ${{ secrets.HARBOR_USERNAME }}
+          password: ${{ secrets.HARBOR_PASSWORD }}
 
       - name: Set up Docker Buildx
         id: buildx
@@ -39,4 +41,4 @@ jobs:
           file: ./Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: jembi/openhim-console:latest
+          tags: harbor.jembidev.org/platform/openhim-console:latest

--- a/.github/workflows/tags.yml
+++ b/.github/workflows/tags.yml
@@ -23,11 +23,12 @@ jobs:
       - name: Set env
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
+      - name: Login to Harbor
+        uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+          registry: harbor.jembidev.org
+          username: ${{ secrets.HARBOR_USERNAME }}
+          password: ${{ secrets.HARBOR_PASSWORD }}
 
       - name: Set up Docker Buildx
         id: buildx
@@ -41,4 +42,4 @@ jobs:
           file: ./Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: jembi/openhim-console:${{ env.RELEASE_VERSION }}
+          tags: harbor.jembidev.org/platform/openhim-console:${{ env.RELEASE_VERSION }}

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ npm test
 
 ## Deployments
 
-All commits to the `master` branch will automatically trigger a build of the latest changes into a docker image on dockerhub.
+All commits to the `master` branch will automatically trigger a build of the latest changes into a Docker image at `harbor.jembidev.org/platform/openhim-console`.
 
 ---
 

--- a/infrastructure/docker-compose.yml
+++ b/infrastructure/docker-compose.yml
@@ -34,7 +34,7 @@ services:
 
   openhim-console:
     container_name: openhim-console
-    image: jembi/openhim-console:latest
+    image: harbor.jembidev.org/platform/openhim-console:latest
     restart: unless-stopped
     networks:
       - openhim


### PR DESCRIPTION
feat(ci): use Harbor registry and update Docker/CI config

- Replace Docker Hub with harbor.jembidev.org/platform/openhim-console
- Add Harbor login (HARBOR_USERNAME/HARBOR_PASSWORD) in master and tags workflows
- Add .github/HARBOR.md with registry setup and auth notes
- Update docker-compose and docker-image-scan to Harbor image

Harbor Image-
<img width="1569" height="472" alt="Screenshot from 2026-03-12 21-20-22" src="https://github.com/user-attachments/assets/1f415d66-e4bb-4846-841a-af0a8cbefce0" />

Workflow pipeline for Harbor
<img width="1883" height="846" alt="Screenshot from 2026-03-12 21-20-10" src="https://github.com/user-attachments/assets/94ff86c7-270d-48ce-b24e-fe5515e54dac" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched CI and deployment processes to use a new container registry for building, scanning, and publishing images.
  * Updated local deployment to include a healthcheck plus port and volume mappings for the console service.

* **Documentation**
  * Updated deployment docs to reference the new container image location.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->